### PR TITLE
AWS Alias Feature for Serverless

### DIFF
--- a/generators/app/templates/_README.md
+++ b/generators/app/templates/_README.md
@@ -2,26 +2,43 @@
 
 This is a monorepo of serverless functions built using yeoman.io generator https://github.com/zotoio/generator-mono-serverless
 
-## install
+## Installation
 Clone this repo.  And perform setup listed at https://github.com/zotoio/generator-mono-serverless
 
-## structure
+## Structure
 All functions are in directories under /packages
 
 Each function has a standalone serverless.yml for independent deployment, while also sharing global libraries and build/test/linting frameworks.
 
-## extending
+## Extending
 You can add new function packages by running the yeoman generator:
+
 ```
 yo mono-serverless:package
 ```
-..and following prompts.  This will give you the scaffolding for a new serverless function.
 
-## deploy
-To deploy a given function, go to the `packages/[function]` dir and run: 
+and following the prompts. This will give you the scaffolding for a new serverless function.
+
+## Deploy
+To deploy a given function, go to the `packages/[function]` dir and run:
+
 ```
 yarn run sls-deploy
 ```
+
 This script will assemble inherited env vars, lint, test and compile the Lambda function, and deploy it to AWS.
 
+On the first run, you must run `yarn run sls-deploy` without arguments to create the baseline CF stack. On subsequent runs, you can append an alias argument to create seperate instances of a function on the same API gateway:
 
+```
+yarn run sls-deploy -- --alias=task-1234
+```
+
+Which can then be accessed by requesting the corresponding path in place of the stage name on the original API gateway URL, such as:
+
+```
+Original URL: https://12345678.execute-api.us-east-1.amazonaws.com/dev/demo
+Alias URL: https://12345678.execute-api.us-east-1.amazonaws.com/task-1234/demo
+```
+
+The original baseline code will remain unchanged when creating new aliases using the above command.

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -22,6 +22,7 @@
         "serverless-offline": "^3.20.2",
         "serverless-plugin-typescript": "^1.1.5",
         "serverless-webpack": "^5.1.0",
+        "serverless-aws-alias": "^1.0.0",
         "ts-jest": "^21.1.4",
         "tslint": "^5.9.1",
         "tslint-config-prettier": "^1.12.0",

--- a/generators/package/templates/_package.json
+++ b/generators/package/templates/_package.json
@@ -12,8 +12,7 @@
         "prebuild": "yarn run clean",
         "predev": "yarn run clean",
         "test": "jest -c ../../jest.json",
-        "sls-deploy":
-            "yarn run build && node --require ../../dotenv.js  ../../node_modules/serverless/bin/serverless deploy -v"
+        "sls-deploy": "yarn run build && node --require ../../dotenv.js ../../node_modules/serverless/bin/serverless deploy -v"
     },
     "devDependencies": {
         "faker": "^4.1.0",

--- a/generators/package/templates/_serverless.yml
+++ b/generators/package/templates/_serverless.yml
@@ -3,6 +3,7 @@ service: <%= name %>
 plugins:
   - serverless-webpack
   - serverless-offline
+  - serverless-aws-alias
 
 provider:
   name: aws

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10710 +1,10802 @@
 {
-  "name": "generator-mono-serverless",
-  "version": "0.0.0",
-  "lockfileVersion": 1,
-  "requires": true,
-  "dependencies": {
-    "@semantic-release/commit-analyzer": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-3.0.7.tgz",
-      "integrity": "sha512-bxCvvDsZeQp6Fvev8CdAV4pu9rEt8NOuLIFS0E8RLjKRnqQVL/fGAwpQWnRQ5hc08UZroguBNEENWpKBubWmKQ==",
-      "dev": true,
-      "requires": {
-        "@semantic-release/error": "2.2.0",
-        "conventional-changelog-angular": "1.6.6",
-        "conventional-commits-parser": "2.1.7",
-        "import-from": "2.1.0",
-        "lodash": "4.17.5",
-        "pify": "3.0.0"
-      }
-    },
-    "@semantic-release/condition-travis": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@semantic-release/condition-travis/-/condition-travis-6.2.1.tgz",
-      "integrity": "sha512-0g8O/OObhqjAotztjPjMJ43I6oX05z/Ffdu6HMsScDgLX1+QQzq5w0HnUxjmiXUGNwqi5M6s7BF65ZKHbGOytQ==",
-      "dev": true,
-      "requires": {
-        "@semantic-release/error": "2.2.0",
-        "github": "12.1.0",
-        "parse-github-repo-url": "1.4.1",
-        "semver": "5.5.0",
-        "travis-deploy-once": "3.3.0"
-      }
-    },
-    "@semantic-release/error": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-2.2.0.tgz",
-      "integrity": "sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg==",
-      "dev": true
-    },
-    "@semantic-release/last-release-npm": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@semantic-release/last-release-npm/-/last-release-npm-2.0.2.tgz",
-      "integrity": "sha512-ge5AWWtcrEd6GeG4tsv8gx774G9aPNrrornjBBqNDqN7Eg/xI914ftcnmSgnsbmKcqmq4g+QElIJhNMvsfpOkQ==",
-      "dev": true,
-      "requires": {
-        "@semantic-release/error": "2.2.0",
-        "npm-registry-client": "8.5.1",
-        "npmlog": "4.1.2"
-      }
-    },
-    "@semantic-release/release-notes-generator": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-4.0.5.tgz",
-      "integrity": "sha512-LznqPnifl8jtQkV5ZXnQbqMLx9QROoX5d/FLteLyKy3AznLSubm5rH0LndKvf9ZI8XU8jwgLYu+wbLAEIR2PPg==",
-      "dev": true,
-      "requires": {
-        "@semantic-release/error": "2.2.0",
-        "conventional-changelog-angular": "1.6.6",
-        "conventional-changelog-core": "1.9.5",
-        "get-stream": "3.0.0",
-        "import-from": "2.1.0",
-        "lodash": "4.17.5",
-        "pify": "3.0.0"
-      }
-    },
-    "@sindresorhus/is": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
-      "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
-      "dev": true
-    },
-    "@types/jest": {
-      "version": "21.1.10",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-21.1.10.tgz",
-      "integrity": "sha512-qDyqzbcyNgW2RgWbl606xCYQ+5fK9khOW5+Hl3wH7RggVES0dB6GcZvpmPs/XIty5qpu1xYCwpiK+iRkJ3xFBw==",
-      "dev": true
-    },
-    "JSONStream": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
-      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
-    },
-    "abab": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
-      "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
-      "dev": true
-    },
-    "abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true
-    },
-    "acorn": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
-      "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
-      "dev": true
-    },
-    "acorn-globals": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
-      "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
-      "dev": true,
-      "requires": {
-        "acorn": "4.0.13"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "4.0.13",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
-          "dev": true
-        }
-      }
-    },
-    "acorn-jsx": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-      "dev": true,
-      "requires": {
-        "acorn": "3.3.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-          "dev": true
-        }
-      }
-    },
-    "agent-base": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
-      "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
-      "dev": true,
-      "requires": {
-        "es6-promisify": "5.0.0"
-      }
-    },
-    "ajv": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-      "dev": true,
-      "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.1.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
-      }
-    },
-    "ajv-keywords": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
-      "dev": true
-    },
-    "align-text": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true,
-      "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
-      }
-    },
-    "amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true
-    },
-    "ansi-escapes": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
-    },
-    "ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-    },
-    "ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "requires": {
-        "color-convert": "1.9.1"
-      }
-    },
-    "anymatch": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-      "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-      "dev": true,
-      "requires": {
-        "micromatch": "3.1.10",
-        "normalize-path": "2.1.1"
-      },
-      "dependencies": {
-        "arr-diff": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-          "dev": true
-        },
-        "array-unique": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-          "dev": true
-        },
-        "braces": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "1.1.0",
-            "array-unique": "0.3.2",
-            "extend-shallow": "2.0.1",
-            "fill-range": "4.0.0",
-            "isobject": "3.0.1",
-            "repeat-element": "1.1.2",
-            "snapdragon": "0.8.2",
-            "snapdragon-node": "2.1.1",
-            "split-string": "3.1.0",
-            "to-regex": "3.0.2"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "0.1.1"
-              }
+    "name": "generator-mono-serverless",
+    "version": "0.0.0",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "@babel/code-frame": {
+            "version": "7.0.0-beta.47",
+            "resolved":
+                "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.47.tgz",
+            "integrity":
+                "sha512-W7IeG4MoVf4oUvWfHUx9VG9if3E0xSUDf1urrnNYtC2ow1dz2ptvQ6YsJfyVXDuPTFXz66jkHhzMW7a5Eld7TA==",
+            "dev": true,
+            "requires": {
+                "@babel/highlight": "7.0.0-beta.47"
             }
-          }
         },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
+        "@babel/highlight": {
+            "version": "7.0.0-beta.47",
+            "resolved":
+                "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.47.tgz",
+            "integrity":
+                "sha512-d505K3Hth1eg0b2swfEF7oFMw3J9M8ceFg0s6dhCSxOOF+07WDvJ0HKT/YbK/Jk9wn8Wyr6HIRAUPKJ9Wfv8Rg==",
+            "dev": true,
+            "requires": {
+                "chalk": "2.4.1",
+                "esutils": "2.0.2",
+                "js-tokens": "3.0.2"
+            }
         },
-        "expand-brackets": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-          "dev": true,
-          "requires": {
-            "debug": "2.6.9",
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "posix-character-classes": "0.1.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "0.2.5",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-              "dev": true,
-              "requires": {
-                "is-descriptor": "0.1.6"
-              }
+        "@mrmlnc/readdir-enhanced": {
+            "version": "2.2.1",
+            "resolved":
+                "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+            "integrity":
+                "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+            "requires": {
+                "call-me-maybe": "1.0.1",
+                "glob-to-regexp": "0.3.0"
+            }
+        },
+        "@nodelib/fs.stat": {
+            "version": "1.0.2",
+            "resolved":
+                "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.0.2.tgz",
+            "integrity":
+                "sha512-vCpf75JDcdomXvUd7Rn6DfYAVqPAFI66FVjxiWGwh85OLdvfo3paBoPJaam5keIYRyUolnS7SleS/ZPCidCvzw=="
+        },
+        "@octokit/rest": {
+            "version": "15.6.0",
+            "resolved":
+                "https://registry.npmjs.org/@octokit/rest/-/rest-15.6.0.tgz",
+            "integrity":
+                "sha512-POCEmRrow+NhEh8cs6aFAXwgExWQ9uNwmZTKr48bgr0czyqgNLcdImHhhMfSV2xHa1wTqj+AdWbrkr+1EpOL+A==",
+            "dev": true,
+            "requires": {
+                "before-after-hook": "1.1.0",
+                "btoa-lite": "1.0.0",
+                "debug": "3.1.0",
+                "http-proxy-agent": "2.1.0",
+                "https-proxy-agent": "2.2.1",
+                "lodash": "4.17.10",
+                "node-fetch": "2.1.2",
+                "url-template": "2.0.8"
+            }
+        },
+        "@semantic-release/commit-analyzer": {
+            "version": "5.0.3",
+            "resolved":
+                "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-5.0.3.tgz",
+            "integrity":
+                "sha512-4GLFDmp8Up+f4GQGPIzLVd8X9a3yqbZjl761sEdfCH4e5FkEO3I9XRlTEfKSueeCt5OA1lZBb9IHGpZ6Ot0+BQ==",
+            "dev": true,
+            "requires": {
+                "conventional-changelog-angular": "3.0.7",
+                "conventional-commits-parser": "2.1.7",
+                "debug": "3.1.0",
+                "import-from": "2.1.0",
+                "lodash": "4.17.10"
+            }
+        },
+        "@semantic-release/error": {
+            "version": "2.2.0",
+            "resolved":
+                "https://registry.npmjs.org/@semantic-release/error/-/error-2.2.0.tgz",
+            "integrity":
+                "sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg==",
+            "dev": true
+        },
+        "@semantic-release/github": {
+            "version": "4.2.16",
+            "resolved":
+                "https://registry.npmjs.org/@semantic-release/github/-/github-4.2.16.tgz",
+            "integrity":
+                "sha512-SuaBvUf7l3RwqdxBKyRSPZnSckEMB0EqBu6658x41hivJXn7KdJnH/EcKNzMeKu8zFJ6a8DrXTY71APVKE3wHg==",
+            "dev": true,
+            "requires": {
+                "@octokit/rest": "15.6.0",
+                "@semantic-release/error": "2.2.0",
+                "aggregate-error": "1.0.0",
+                "bottleneck": "2.3.0",
+                "debug": "3.1.0",
+                "fs-extra": "6.0.1",
+                "globby": "8.0.1",
+                "issue-parser": "2.0.0",
+                "lodash": "4.17.10",
+                "mime": "2.3.1",
+                "p-filter": "1.0.0",
+                "p-retry": "2.0.0",
+                "parse-github-url": "1.0.2",
+                "url-join": "4.0.0"
             },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "0.1.1"
-              }
-            },
-            "is-accessor-descriptor": {
-              "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-              "dev": true,
-              "requires": {
-                "kind-of": "3.2.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "1.1.6"
-                  }
+            "dependencies": {
+                "fs-extra": {
+                    "version": "6.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
+                    "integrity":
+                        "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "jsonfile": "4.0.0",
+                        "universalify": "0.1.1"
+                    }
+                },
+                "jsonfile": {
+                    "version": "4.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+                    "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11"
+                    }
                 }
-              }
+            }
+        },
+        "@semantic-release/npm": {
+            "version": "3.2.5",
+            "resolved":
+                "https://registry.npmjs.org/@semantic-release/npm/-/npm-3.2.5.tgz",
+            "integrity":
+                "sha512-I40tCW1S3QY4hStrg5PGnRI7Y8N5XVnsG9grEkEKSZmcuBPWC1ag5YcSPxnlsOzbsb94wRPwJTKuzNo7/nA2iQ==",
+            "dev": true,
+            "requires": {
+                "@semantic-release/error": "2.2.0",
+                "aggregate-error": "1.0.0",
+                "execa": "0.10.0",
+                "fs-extra": "6.0.1",
+                "lodash": "4.17.10",
+                "nerf-dart": "1.0.0",
+                "normalize-url": "2.0.1",
+                "read-pkg": "3.0.0",
+                "registry-auth-token": "3.3.2"
             },
-            "is-data-descriptor": {
-              "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-              "dev": true,
-              "requires": {
-                "kind-of": "3.2.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "1.1.6"
-                  }
+            "dependencies": {
+                "execa": {
+                    "version": "0.10.0",
+                    "resolved":
+                        "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+                    "integrity":
+                        "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "6.0.5",
+                        "get-stream": "3.0.0",
+                        "is-stream": "1.1.0",
+                        "npm-run-path": "2.0.2",
+                        "p-finally": "1.0.0",
+                        "signal-exit": "3.0.2",
+                        "strip-eof": "1.0.0"
+                    }
+                },
+                "fs-extra": {
+                    "version": "6.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
+                    "integrity":
+                        "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "jsonfile": "4.0.0",
+                        "universalify": "0.1.1"
+                    }
+                },
+                "jsonfile": {
+                    "version": "4.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+                    "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11"
+                    }
                 }
-              }
+            }
+        },
+        "@semantic-release/release-notes-generator": {
+            "version": "6.0.10",
+            "resolved":
+                "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-6.0.10.tgz",
+            "integrity":
+                "sha512-8eigxfGSy36+mv4rUIbGZAGZkUVZYNXOyRpcG+ZHSeGTqG6hu9uUxmzkfQ2hvK3zSxqrzKPg3MxnhvZL1Qqmrg==",
+            "dev": true,
+            "requires": {
+                "conventional-changelog-angular": "3.0.7",
+                "conventional-changelog-writer": "3.0.9",
+                "conventional-commits-parser": "2.1.7",
+                "debug": "3.1.0",
+                "get-stream": "3.0.0",
+                "git-url-parse": "9.0.0",
+                "import-from": "2.1.0",
+                "into-stream": "3.1.0",
+                "lodash": "4.17.10"
+            }
+        },
+        "@sinonjs/formatio": {
+            "version": "2.0.0",
+            "resolved":
+                "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+            "integrity":
+                "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+            "dev": true,
+            "requires": {
+                "samsam": "1.3.0"
+            }
+        },
+        "@types/jest": {
+            "version": "22.2.3",
+            "resolved":
+                "https://registry.npmjs.org/@types/jest/-/jest-22.2.3.tgz",
+            "integrity":
+                "sha512-e74sM9W/4qqWB6D4TWV9FQk0WoHtX1X4FJpbjxucMSVJHtFjbQOH3H6yp+xno4br0AKG0wz/kPtaN599GUOvAg==",
+            "dev": true
+        },
+        "abab": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
+            "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
+            "dev": true
+        },
+        "acorn": {
+            "version": "5.5.3",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+            "integrity":
+                "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
+            "dev": true
+        },
+        "acorn-globals": {
+            "version": "4.1.0",
+            "resolved":
+                "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
+            "integrity":
+                "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
+            "dev": true,
+            "requires": {
+                "acorn": "5.5.3"
+            }
+        },
+        "acorn-jsx": {
+            "version": "3.0.1",
+            "resolved":
+                "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+            "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+            "dev": true,
+            "requires": {
+                "acorn": "3.3.0"
             },
-            "is-descriptor": {
-              "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
-              }
+            "dependencies": {
+                "acorn": {
+                    "version": "3.3.0",
+                    "resolved":
+                        "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+                    "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+                    "dev": true
+                }
+            }
+        },
+        "agent-base": {
+            "version": "4.2.0",
+            "resolved":
+                "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
+            "integrity":
+                "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
+            "dev": true,
+            "requires": {
+                "es6-promisify": "5.0.0"
+            }
+        },
+        "aggregate-error": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/aggregate-error/-/aggregate-error-1.0.0.tgz",
+            "integrity": "sha1-iINE2tAiCnLjr1CQYRf0h3GSX6w=",
+            "dev": true,
+            "requires": {
+                "clean-stack": "1.3.0",
+                "indent-string": "3.2.0"
             },
-            "kind-of": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-              "dev": true
+            "dependencies": {
+                "indent-string": {
+                    "version": "3.2.0",
+                    "resolved":
+                        "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+                    "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+                    "dev": true
+                }
             }
-          }
-        },
-        "extglob": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-          "dev": true,
-          "requires": {
-            "array-unique": "0.3.2",
-            "define-property": "1.0.0",
-            "expand-brackets": "2.1.4",
-            "extend-shallow": "2.0.1",
-            "fragment-cache": "0.2.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-              "dev": true,
-              "requires": {
-                "is-descriptor": "1.0.2"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "0.1.1"
-              }
-            }
-          }
-        },
-        "fill-range": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "2.0.1",
-            "is-number": "3.0.0",
-            "repeat-string": "1.6.1",
-            "to-regex-range": "2.1.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "0.1.1"
-              }
-            }
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-          "dev": true,
-          "requires": {
-            "kind-of": "6.0.2"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-          "dev": true,
-          "requires": {
-            "kind-of": "6.0.2"
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
-          }
-        },
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
-        },
-        "micromatch": {
-          "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-          "dev": true,
-          "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "braces": "2.3.2",
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "extglob": "2.0.4",
-            "fragment-cache": "0.2.1",
-            "kind-of": "6.0.2",
-            "nanomatch": "1.2.9",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
-          }
-        },
-        "normalize-path": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-          "dev": true,
-          "requires": {
-            "remove-trailing-separator": "1.1.0"
-          }
-        }
-      }
-    },
-    "app-root-path": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.0.1.tgz",
-      "integrity": "sha1-zWLc+OT9WkF+/GZNLlsQZTxlG0Y=",
-      "dev": true
-    },
-    "append-transform": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
-      "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
-      "dev": true,
-      "requires": {
-        "default-require-extensions": "1.0.0"
-      }
-    },
-    "aproba": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-      "dev": true
-    },
-    "are-we-there-yet": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-      "dev": true,
-      "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.6"
-      }
-    },
-    "argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "requires": {
-        "sprintf-js": "1.0.3"
-      }
-    },
-    "arr-diff": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "dev": true,
-      "requires": {
-        "arr-flatten": "1.1.0"
-      }
-    },
-    "arr-flatten": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-      "dev": true
-    },
-    "arr-union": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
-      "dev": true
-    },
-    "array-differ": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
-    },
-    "array-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
-      "dev": true
-    },
-    "array-find-index": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
-      "dev": true
-    },
-    "array-ify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-      "integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
-      "dev": true
-    },
-    "array-union": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "requires": {
-        "array-uniq": "1.0.3"
-      }
-    },
-    "array-uniq": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
-    },
-    "array-unique": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-      "dev": true
-    },
-    "arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
-    },
-    "asn1": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-      "dev": true
-    },
-    "assert-plus": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-      "dev": true
-    },
-    "assign-symbols": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
-      "dev": true
-    },
-    "astral-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
-      "dev": true
-    },
-    "async": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-      "requires": {
-        "lodash": "4.17.5"
-      }
-    },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
-    },
-    "atob": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.0.tgz",
-      "integrity": "sha512-SuiKH8vbsOyCALjA/+EINmt/Kdl+TQPrtFgW7XZZcwtryFu9e5kQoX3bjCW6mIvGH1fbeAZZuvwGR5IlBRznGw==",
-      "dev": true
-    },
-    "aws-sign2": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-      "dev": true
-    },
-    "aws4": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
-      "dev": true
-    },
-    "babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
-      }
-    },
-    "babel-core": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
-      "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-generator": "6.26.1",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "convert-source-map": "1.5.1",
-        "debug": "2.6.9",
-        "json5": "0.5.1",
-        "lodash": "4.17.5",
-        "minimatch": "3.0.4",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.8",
-        "slash": "1.0.0",
-        "source-map": "0.5.7"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "babel-generator": {
-      "version": "6.26.1",
-      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
-      "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
-      "dev": true,
-      "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.5",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
-      }
-    },
-    "babel-helpers": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
-      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
-      }
-    },
-    "babel-jest": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-21.2.0.tgz",
-      "integrity": "sha512-O0W2qLoWu1QOoOGgxiR2JID4O6WSpxPiQanrkyi9SSlM0PJ60Ptzlck47lhtnr9YZO3zYOsxHwnyeWJ6AffoBQ==",
-      "dev": true,
-      "requires": {
-        "babel-plugin-istanbul": "4.1.6",
-        "babel-preset-jest": "21.2.0"
-      }
-    },
-    "babel-messages": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-istanbul": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
-      "integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
-      "dev": true,
-      "requires": {
-        "babel-plugin-syntax-object-rest-spread": "6.13.0",
-        "find-up": "2.1.0",
-        "istanbul-lib-instrument": "1.10.1",
-        "test-exclude": "4.2.1"
-      }
-    },
-    "babel-plugin-jest-hoist": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-21.2.0.tgz",
-      "integrity": "sha512-yi5QuiVyyvhBUDLP4ButAnhYzkdrUwWDtvUJv71hjH3fclhnZg4HkDeqaitcR2dZZx/E67kGkRcPVjtVu+SJfQ==",
-      "dev": true
-    },
-    "babel-plugin-syntax-object-rest-spread": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
-      "dev": true
-    },
-    "babel-preset-jest": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-21.2.0.tgz",
-      "integrity": "sha512-hm9cBnr2h3J7yXoTtAVV0zg+3vg0Q/gT2GYuzlreTU0EPkJRtlNgKJJ3tBKEn0+VjAi3JykV6xCJkuUYttEEfA==",
-      "dev": true,
-      "requires": {
-        "babel-plugin-jest-hoist": "21.2.0",
-        "babel-plugin-syntax-object-rest-spread": "6.13.0"
-      }
-    },
-    "babel-register": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
-      "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-      "dev": true,
-      "requires": {
-        "babel-core": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.5",
-        "home-or-tmp": "2.0.0",
-        "lodash": "4.17.5",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.18"
-      }
-    },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
-      "requires": {
-        "core-js": "2.5.5",
-        "regenerator-runtime": "0.11.1"
-      }
-    },
-    "babel-template": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "lodash": "4.17.5"
-      }
-    },
-    "babel-traverse": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.9",
-        "globals": "9.18.0",
-        "invariant": "2.2.4",
-        "lodash": "4.17.5"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "globals": {
-          "version": "9.18.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-          "dev": true
-        }
-      }
-    },
-    "babel-types": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.5",
-        "to-fast-properties": "1.0.3"
-      }
-    },
-    "babylon": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-      "dev": true
-    },
-    "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-    },
-    "base": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
-      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
-      "dev": true,
-      "requires": {
-        "cache-base": "1.0.1",
-        "class-utils": "0.3.6",
-        "component-emitter": "1.2.1",
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "mixin-deep": "1.3.1",
-        "pascalcase": "0.1.1"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-          "dev": true,
-          "requires": {
-            "is-descriptor": "1.0.2"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-          "dev": true,
-          "requires": {
-            "kind-of": "6.0.2"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-          "dev": true,
-          "requires": {
-            "kind-of": "6.0.2"
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
-        }
-      }
-    },
-    "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "tweetnacl": "0.14.5"
-      }
-    },
-    "binaryextensions": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.1.1.tgz",
-      "integrity": "sha512-XBaoWE9RW8pPdPQNibZsW2zh8TW6gcarXp1FZPwT8Uop8ScSNldJEWf2k9l3HeTqdrEwsOsFcq74RiJECW34yA=="
-    },
-    "boom": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "dev": true,
-      "requires": {
-        "hoek": "2.16.3"
-      }
-    },
-    "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "requires": {
-        "balanced-match": "1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "braces": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-      "dev": true,
-      "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
-      }
-    },
-    "browser-resolve": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
-      "integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
-      "dev": true,
-      "requires": {
-        "resolve": "1.1.7"
-      },
-      "dependencies": {
-        "resolve": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-          "dev": true
-        }
-      }
-    },
-    "bser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
-      "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
-      "dev": true,
-      "requires": {
-        "node-int64": "0.4.0"
-      }
-    },
-    "buffer-from": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
-      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
-      "dev": true
-    },
-    "builtin-modules": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
-    },
-    "builtins": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
-      "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
-      "dev": true
-    },
-    "cache-base": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
-      "dev": true,
-      "requires": {
-        "collection-visit": "1.0.0",
-        "component-emitter": "1.2.1",
-        "get-value": "2.0.6",
-        "has-value": "1.0.0",
-        "isobject": "3.0.1",
-        "set-value": "2.0.0",
-        "to-object-path": "0.3.0",
-        "union-value": "1.0.0",
-        "unset-value": "1.0.0"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        }
-      }
-    },
-    "cacheable-request": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
-      "integrity": "sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=",
-      "dev": true,
-      "requires": {
-        "clone-response": "1.0.2",
-        "get-stream": "3.0.0",
-        "http-cache-semantics": "3.8.1",
-        "keyv": "3.0.0",
-        "lowercase-keys": "1.0.0",
-        "normalize-url": "2.0.1",
-        "responselike": "1.0.2"
-      },
-      "dependencies": {
-        "lowercase-keys": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-          "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
-          "dev": true
-        }
-      }
-    },
-    "caller-path": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true,
-      "requires": {
-        "callsites": "0.2.0"
-      }
-    },
-    "callsites": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
-      "dev": true
-    },
-    "camelcase": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-      "dev": true,
-      "optional": true
-    },
-    "camelcase-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
-      "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
-      "dev": true,
-      "requires": {
-        "camelcase": "4.1.0",
-        "map-obj": "2.0.0",
-        "quick-lru": "1.1.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
-        }
-      }
-    },
-    "capture-stack-trace": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
-      "dev": true
-    },
-    "caseless": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
-      "dev": true
-    },
-    "center-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
-      }
-    },
-    "chalk": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-      "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
-      "requires": {
-        "ansi-styles": "3.2.1",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.4.0"
-      }
-    },
-    "chardet": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
-    },
-    "chownr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
-      "dev": true,
-      "optional": true
-    },
-    "ci-info": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
-      "integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
-      "dev": true
-    },
-    "circular-json": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
-      "dev": true
-    },
-    "class-extend": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/class-extend/-/class-extend-0.1.2.tgz",
-      "integrity": "sha1-gFeoKwD1P4Kl1ixQ74z/3sb6vDQ=",
-      "dev": true,
-      "requires": {
-        "object-assign": "2.1.1"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
-          "dev": true
-        }
-      }
-    },
-    "class-utils": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
-      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
-      "dev": true,
-      "requires": {
-        "arr-union": "3.1.0",
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "static-extend": "0.1.2"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true,
-          "requires": {
-            "is-descriptor": "0.1.6"
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        }
-      }
-    },
-    "cli-boxes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
-    },
-    "cli-cursor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-      "requires": {
-        "restore-cursor": "2.0.0"
-      }
-    },
-    "cli-spinners": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz",
-      "integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=",
-      "dev": true
-    },
-    "cli-table": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
-      "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
-      "requires": {
-        "colors": "1.0.3"
-      }
-    },
-    "cli-truncate": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
-      "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
-      "dev": true,
-      "requires": {
-        "slice-ansi": "0.0.4",
-        "string-width": "1.0.2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "slice-ansi": {
-          "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-          "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        }
-      }
-    },
-    "cli-width": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
-    },
-    "cliui": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
-        "wordwrap": "0.0.2"
-      },
-      "dependencies": {
-        "wordwrap": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "dev": true,
-          "optional": true
-        }
-      }
-    },
-    "clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
-    },
-    "clone-buffer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
-      "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg="
-    },
-    "clone-response": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
-      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
-      "dev": true,
-      "requires": {
-        "mimic-response": "1.0.0"
-      }
-    },
-    "clone-stats": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-      "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
-    },
-    "cloneable-readable": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
-      "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
-      "requires": {
-        "inherits": "2.0.3",
-        "process-nextick-args": "2.0.0",
-        "readable-stream": "2.3.6"
-      }
-    },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
-    },
-    "code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-    },
-    "collection-visit": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
-      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
-      "dev": true,
-      "requires": {
-        "map-visit": "1.0.0",
-        "object-visit": "1.0.1"
-      }
-    },
-    "color-convert": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-      "requires": {
-        "color-name": "1.1.3"
-      }
-    },
-    "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-    },
-    "colors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
-    },
-    "combined-stream": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-      "dev": true,
-      "requires": {
-        "delayed-stream": "1.0.0"
-      }
-    },
-    "commander": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
-      "dev": true
-    },
-    "commondir": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
-    },
-    "compare-func": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
-      "integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
-      "dev": true,
-      "requires": {
-        "array-ify": "1.0.0",
-        "dot-prop": "3.0.0"
-      }
-    },
-    "compare-versions": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.1.0.tgz",
-      "integrity": "sha512-4hAxDSBypT/yp2ySFD346So6Ragw5xmBn/e/agIGl3bZr6DLUqnoRZPusxKrXdYRZpgexO9daejmIenlq/wrIQ==",
-      "dev": true
-    },
-    "component-emitter": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-      "dev": true
-    },
-    "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-    },
-    "concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "dev": true,
-      "requires": {
-        "buffer-from": "1.0.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6",
-        "typedarray": "0.0.6"
-      }
-    },
-    "config-chain": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
-      "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
-      "dev": true,
-      "requires": {
-        "ini": "1.3.5",
-        "proto-list": "1.2.4"
-      }
-    },
-    "console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true
-    },
-    "content-type-parser": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
-      "integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ==",
-      "dev": true
-    },
-    "conventional-changelog-angular": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz",
-      "integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
-      "dev": true,
-      "requires": {
-        "compare-func": "1.3.2",
-        "q": "1.5.1"
-      }
-    },
-    "conventional-changelog-core": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-1.9.5.tgz",
-      "integrity": "sha1-XbdWba18DLddr0f7spdve/mSjB0=",
-      "dev": true,
-      "requires": {
-        "conventional-changelog-writer": "2.0.3",
-        "conventional-commits-parser": "2.1.7",
-        "dateformat": "1.0.12",
-        "get-pkg-repo": "1.4.0",
-        "git-raw-commits": "1.3.6",
-        "git-remote-origin-url": "2.0.0",
-        "git-semver-tags": "1.3.6",
-        "lodash": "4.17.5",
-        "normalize-package-data": "2.4.0",
-        "q": "1.5.1",
-        "read-pkg": "1.1.0",
-        "read-pkg-up": "1.0.1",
-        "through2": "2.0.3"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-          "dev": true
-        },
-        "camelcase-keys": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-          "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-          "dev": true,
-          "requires": {
-            "camelcase": "2.1.1",
-            "map-obj": "1.0.1"
-          }
-        },
-        "dateformat": {
-          "version": "1.0.12",
-          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-          "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "4.0.1",
-            "meow": "3.7.0"
-          }
-        },
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
-          }
-        },
-        "map-obj": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-          "dev": true
-        },
-        "meow": {
-          "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-          "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-          "dev": true,
-          "requires": {
-            "camelcase-keys": "2.1.0",
-            "decamelize": "1.2.0",
-            "loud-rejection": "1.6.0",
-            "map-obj": "1.0.1",
-            "minimist": "1.2.0",
-            "normalize-package-data": "2.4.0",
-            "object-assign": "4.1.1",
-            "read-pkg-up": "1.0.1",
-            "redent": "1.0.0",
-            "trim-newlines": "1.0.0"
-          }
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "1.3.1"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "dev": true,
-          "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
-          }
-        },
-        "redent": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-          "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-          "dev": true,
-          "requires": {
-            "indent-string": "2.1.0",
-            "strip-indent": "1.0.1"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
-        },
-        "strip-indent": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-          "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "4.0.1"
-          }
-        },
-        "trim-newlines": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-          "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-          "dev": true
-        }
-      }
-    },
-    "conventional-changelog-writer": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-2.0.3.tgz",
-      "integrity": "sha512-2E1h7UXL0fhRO5h0CxDZ5EBc5sfBZEQePvuZ+gPvApiRrICUyNDy/NQIP+2TBd4wKZQf2Zm7TxbzXHG5HkPIbA==",
-      "dev": true,
-      "requires": {
-        "compare-func": "1.3.2",
-        "conventional-commits-filter": "1.1.6",
-        "dateformat": "1.0.12",
-        "handlebars": "4.0.11",
-        "json-stringify-safe": "5.0.1",
-        "lodash": "4.17.5",
-        "meow": "3.7.0",
-        "semver": "5.5.0",
-        "split": "1.0.1",
-        "through2": "2.0.3"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-          "dev": true
-        },
-        "camelcase-keys": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-          "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-          "dev": true,
-          "requires": {
-            "camelcase": "2.1.1",
-            "map-obj": "1.0.1"
-          }
-        },
-        "dateformat": {
-          "version": "1.0.12",
-          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-          "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "4.0.1",
-            "meow": "3.7.0"
-          }
-        },
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
-          }
-        },
-        "map-obj": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-          "dev": true
-        },
-        "meow": {
-          "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-          "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-          "dev": true,
-          "requires": {
-            "camelcase-keys": "2.1.0",
-            "decamelize": "1.2.0",
-            "loud-rejection": "1.6.0",
-            "map-obj": "1.0.1",
-            "minimist": "1.2.0",
-            "normalize-package-data": "2.4.0",
-            "object-assign": "4.1.1",
-            "read-pkg-up": "1.0.1",
-            "redent": "1.0.0",
-            "trim-newlines": "1.0.0"
-          }
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "1.3.1"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "dev": true,
-          "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
-          }
-        },
-        "redent": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-          "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-          "dev": true,
-          "requires": {
-            "indent-string": "2.1.0",
-            "strip-indent": "1.0.1"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
-        },
-        "strip-indent": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-          "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "4.0.1"
-          }
-        },
-        "trim-newlines": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-          "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-          "dev": true
-        }
-      }
-    },
-    "conventional-commits-filter": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.1.6.tgz",
-      "integrity": "sha512-KcDgtCRKJCQhyk6VLT7zR+ZOyCnerfemE/CsR3iQpzRRFbLEs0Y6rwk3mpDvtOh04X223z+1xyJ582Stfct/0Q==",
-      "dev": true,
-      "requires": {
-        "is-subset": "0.1.1",
-        "modify-values": "1.0.1"
-      }
-    },
-    "conventional-commits-parser": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.7.tgz",
-      "integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
-      "dev": true,
-      "requires": {
-        "JSONStream": "1.3.2",
-        "is-text-path": "1.0.1",
-        "lodash": "4.17.5",
-        "meow": "4.0.0",
-        "split2": "2.2.0",
-        "through2": "2.0.3",
-        "trim-off-newlines": "1.0.1"
-      }
-    },
-    "convert-source-map": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
-      "dev": true
-    },
-    "copy-descriptor": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
-      "dev": true
-    },
-    "core-js": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
-      "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
-      "dev": true
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "cosmiconfig": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-1.1.0.tgz",
-      "integrity": "sha1-DeoPmATv37kp+7GxiOJVU+oFPTc=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "js-yaml": "3.11.0",
-        "minimist": "1.2.0",
-        "object-assign": "4.1.1",
-        "os-homedir": "1.0.2",
-        "parse-json": "2.2.0",
-        "pinkie-promise": "2.0.1",
-        "require-from-string": "1.2.1"
-      },
-      "dependencies": {
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "1.3.1"
-          }
-        }
-      }
-    },
-    "coveralls": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.3.tgz",
-      "integrity": "sha512-iiAmn+l1XqRwNLXhW8Rs5qHZRFMYp9ZIPjEOVRpC/c4so6Y/f4/lFi0FfR5B9cCqgyhkJ5cZmbvcVRfP8MHchw==",
-      "dev": true,
-      "requires": {
-        "js-yaml": "3.6.1",
-        "lcov-parse": "0.0.10",
-        "log-driver": "1.2.5",
-        "minimist": "1.2.0",
-        "request": "2.79.0"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-          "dev": true
-        },
-        "js-yaml": {
-          "version": "3.6.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
-          "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
-          "dev": true,
-          "requires": {
-            "argparse": "1.0.10",
-            "esprima": "2.7.3"
-          }
-        }
-      }
-    },
-    "create-error-class": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
-      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-      "dev": true,
-      "requires": {
-        "capture-stack-trace": "1.0.0"
-      }
-    },
-    "cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-      "requires": {
-        "lru-cache": "4.1.2",
-        "shebang-command": "1.2.0",
-        "which": "1.3.0"
-      }
-    },
-    "cryptiles": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "dev": true,
-      "requires": {
-        "boom": "2.10.1"
-      }
-    },
-    "cssom": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
-      "integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs=",
-      "dev": true
-    },
-    "cssstyle": {
-      "version": "0.2.37",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
-      "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
-      "dev": true,
-      "requires": {
-        "cssom": "0.3.2"
-      }
-    },
-    "currently-unhandled": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-      "dev": true,
-      "requires": {
-        "array-find-index": "1.0.2"
-      }
-    },
-    "dargs": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/dargs/-/dargs-5.1.0.tgz",
-      "integrity": "sha1-7H6lDHhWTNNsnV7Bj2Yyn63ieCk="
-    },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
-      }
-    },
-    "date-fns": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
-      "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
-      "dev": true
-    },
-    "dateformat": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
-    },
-    "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "requires": {
-        "ms": "2.0.0"
-      }
-    },
-    "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
-    },
-    "decamelize-keys": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
-      "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
-      "dev": true,
-      "requires": {
-        "decamelize": "1.2.0",
-        "map-obj": "1.0.1"
-      },
-      "dependencies": {
-        "map-obj": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-          "dev": true
-        }
-      }
-    },
-    "decode-uri-component": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
-    },
-    "decompress-response": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-      "requires": {
-        "mimic-response": "1.0.0"
-      }
-    },
-    "deep-extend": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
-    },
-    "deep-is": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true
-    },
-    "default-require-extensions": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
-      "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
-      "dev": true,
-      "requires": {
-        "strip-bom": "2.0.0"
-      },
-      "dependencies": {
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
-        }
-      }
-    },
-    "define-property": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
-      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
-      "dev": true,
-      "requires": {
-        "is-descriptor": "1.0.2",
-        "isobject": "3.0.1"
-      },
-      "dependencies": {
-        "is-accessor-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-          "dev": true,
-          "requires": {
-            "kind-of": "6.0.2"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-          "dev": true,
-          "requires": {
-            "kind-of": "6.0.2"
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
-        }
-      }
-    },
-    "del": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true,
-      "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.1",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2"
-      },
-      "dependencies": {
-        "globby": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-          "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-          "dev": true,
-          "requires": {
-            "array-union": "1.0.2",
-            "arrify": "1.0.1",
-            "glob": "7.1.2",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        }
-      }
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
-    },
-    "delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-      "dev": true
-    },
-    "detect-conflict": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/detect-conflict/-/detect-conflict-1.0.1.tgz",
-      "integrity": "sha1-CIZXpmqWHAUBnbfEIwiDsca0F24="
-    },
-    "detect-indent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-      "dev": true,
-      "requires": {
-        "repeating": "2.0.1"
-      }
-    },
-    "diff": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
-    },
-    "doctrine": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-      "dev": true,
-      "requires": {
-        "esutils": "2.0.2"
-      }
-    },
-    "dot-prop": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
-      "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
-      "dev": true,
-      "requires": {
-        "is-obj": "1.0.1"
-      }
-    },
-    "dotenv": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
-      "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0=",
-      "dev": true
-    },
-    "duplexer3": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
-    },
-    "ecc-jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "jsbn": "0.1.1"
-      }
-    },
-    "editions": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
-      "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
-    },
-    "ejs": {
-      "version": "2.5.9",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.9.tgz",
-      "integrity": "sha512-GJCAeDBKfREgkBtgrYSf9hQy9kTb3helv0zGdzqhM7iAkW8FA/ZF97VQDbwFiwIT8MQLLOe5VlPZOEvZAqtUAQ=="
-    },
-    "elegant-spinner": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
-      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
-      "dev": true
-    },
-    "errno": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
-      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
-      "dev": true,
-      "requires": {
-        "prr": "1.0.1"
-      }
-    },
-    "error": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/error/-/error-7.0.2.tgz",
-      "integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
-      "requires": {
-        "string-template": "0.2.1",
-        "xtend": "4.0.1"
-      }
-    },
-    "error-ex": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-      "requires": {
-        "is-arrayish": "0.2.1"
-      }
-    },
-    "es6-promise": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
-      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
-      "dev": true
-    },
-    "es6-promisify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "dev": true,
-      "requires": {
-        "es6-promise": "4.2.4"
-      }
-    },
-    "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-    },
-    "escodegen": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
-      "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
-      "dev": true,
-      "requires": {
-        "esprima": "3.1.3",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.6.1"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true,
-          "optional": true
-        }
-      }
-    },
-    "eslint": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
-      "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
-      "dev": true,
-      "requires": {
-        "ajv": "5.5.2",
-        "babel-code-frame": "6.26.0",
-        "chalk": "2.4.0",
-        "concat-stream": "1.6.2",
-        "cross-spawn": "5.1.0",
-        "debug": "3.1.0",
-        "doctrine": "2.1.0",
-        "eslint-scope": "3.7.1",
-        "eslint-visitor-keys": "1.0.0",
-        "espree": "3.5.4",
-        "esquery": "1.0.1",
-        "esutils": "2.0.2",
-        "file-entry-cache": "2.0.0",
-        "functional-red-black-tree": "1.0.1",
-        "glob": "7.1.2",
-        "globals": "11.4.0",
-        "ignore": "3.3.7",
-        "imurmurhash": "0.1.4",
-        "inquirer": "3.3.0",
-        "is-resolvable": "1.1.0",
-        "js-yaml": "3.11.0",
-        "json-stable-stringify-without-jsonify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.5",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "pluralize": "7.0.0",
-        "progress": "2.0.0",
-        "regexpp": "1.1.0",
-        "require-uncached": "1.0.3",
-        "semver": "5.5.0",
-        "strip-ansi": "4.0.0",
-        "strip-json-comments": "2.0.1",
-        "table": "4.0.2",
-        "text-table": "0.2.0"
-      }
-    },
-    "eslint-config-prettier": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-2.9.0.tgz",
-      "integrity": "sha512-ag8YEyBXsm3nmOv1Hz991VtNNDMRa+MNy8cY47Pl4bw6iuzqKbJajXdqUpiw13STdLLrznxgm1hj9NhxeOYq0A==",
-      "dev": true,
-      "requires": {
-        "get-stdin": "5.0.1"
-      },
-      "dependencies": {
-        "get-stdin": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
-          "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
-          "dev": true
-        }
-      }
-    },
-    "eslint-config-xo": {
-      "version": "0.18.2",
-      "resolved": "https://registry.npmjs.org/eslint-config-xo/-/eslint-config-xo-0.18.2.tgz",
-      "integrity": "sha1-ChVxIIdWGZKec1/9axhcQeihh68=",
-      "dev": true
-    },
-    "eslint-plugin-prettier": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.0.tgz",
-      "integrity": "sha512-floiaI4F7hRkTrFe8V2ItOK97QYrX75DjmdzmVITZoAP6Cn06oEDPQRsO6MlHEP/u2SxI3xQ52Kpjw6j5WGfeQ==",
-      "dev": true,
-      "requires": {
-        "fast-diff": "1.1.2",
-        "jest-docblock": "21.2.0"
-      }
-    },
-    "eslint-scope": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
-      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
-      "dev": true,
-      "requires": {
-        "esrecurse": "4.2.1",
-        "estraverse": "4.2.0"
-      }
-    },
-    "eslint-visitor-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
-      "dev": true
-    },
-    "espree": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
-      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
-      "dev": true,
-      "requires": {
-        "acorn": "5.5.3",
-        "acorn-jsx": "3.0.1"
-      }
-    },
-    "esprima": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-      "dev": true
-    },
-    "esquery": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
-      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
-      "dev": true,
-      "requires": {
-        "estraverse": "4.2.0"
-      }
-    },
-    "esrecurse": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
-      "dev": true,
-      "requires": {
-        "estraverse": "4.2.0"
-      }
-    },
-    "estraverse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-      "dev": true
-    },
-    "esutils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-      "dev": true
-    },
-    "exec-sh": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
-      "integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
-      "dev": true,
-      "requires": {
-        "merge": "1.2.0"
-      }
-    },
-    "execa": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "5.1.0",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
-      }
-    },
-    "exit-hook": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
-      "dev": true
-    },
-    "expand-brackets": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-      "dev": true,
-      "requires": {
-        "is-posix-bracket": "0.1.1"
-      }
-    },
-    "expand-range": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "dev": true,
-      "requires": {
-        "fill-range": "2.2.3"
-      }
-    },
-    "expect": {
-      "version": "21.2.1",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-21.2.1.tgz",
-      "integrity": "sha512-orfQQqFRTX0jH7znRIGi8ZMR8kTNpXklTTz8+HGTpmTKZo3Occ6JNB5FXMb8cRuiiC/GyDqsr30zUa66ACYlYw==",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "3.2.1",
-        "jest-diff": "21.2.1",
-        "jest-get-type": "21.2.0",
-        "jest-matcher-utils": "21.2.1",
-        "jest-message-util": "21.2.1",
-        "jest-regex-util": "21.2.0"
-      }
-    },
-    "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-      "dev": true
-    },
-    "extend-shallow": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-      "dev": true,
-      "requires": {
-        "assign-symbols": "1.0.0",
-        "is-extendable": "1.0.1"
-      },
-      "dependencies": {
-        "is-extendable": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-          "dev": true,
-          "requires": {
-            "is-plain-object": "2.0.4"
-          }
-        }
-      }
-    },
-    "external-editor": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
-      "requires": {
-        "chardet": "0.4.2",
-        "iconv-lite": "0.4.21",
-        "tmp": "0.0.33"
-      }
-    },
-    "extglob": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-      "dev": true,
-      "requires": {
-        "is-extglob": "1.0.0"
-      }
-    },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
-    },
-    "faker": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/faker/-/faker-4.1.0.tgz",
-      "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8=",
-      "dev": true
-    },
-    "fast-deep-equal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
-      "dev": true
-    },
-    "fast-diff": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
-      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
-      "dev": true
-    },
-    "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
-    },
-    "fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
-    },
-    "fb-watchman": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
-      "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
-      "dev": true,
-      "requires": {
-        "bser": "2.0.0"
-      }
-    },
-    "figures": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-      "requires": {
-        "escape-string-regexp": "1.0.5"
-      }
-    },
-    "file-entry-cache": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-      "dev": true,
-      "requires": {
-        "flat-cache": "1.3.0",
-        "object-assign": "4.1.1"
-      }
-    },
-    "filename-regex": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-      "dev": true
-    },
-    "fileset": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
-      "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
-      "dev": true,
-      "requires": {
-        "glob": "7.1.2",
-        "minimatch": "3.0.4"
-      }
-    },
-    "fill-range": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-      "dev": true,
-      "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "1.1.7",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
-      }
-    },
-    "find-up": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-      "requires": {
-        "locate-path": "2.0.0"
-      }
-    },
-    "first-chunk-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
-      "integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
-      "requires": {
-        "readable-stream": "2.3.6"
-      }
-    },
-    "flat-cache": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
-      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
-      "dev": true,
-      "requires": {
-        "circular-json": "0.3.3",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
-      }
-    },
-    "follow-redirects": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.6.tgz",
-      "integrity": "sha512-FrMqZ/FONtHnbqO651UPpfRUVukIEwJhXMfdr/JWAmrDbeYBu773b1J6gdWDyRIj4hvvzQEHoEOTrdR8o6KLYA==",
-      "dev": true,
-      "requires": {
-        "debug": "3.1.0"
-      }
-    },
-    "for-in": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-      "dev": true
-    },
-    "for-own": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "dev": true,
-      "requires": {
-        "for-in": "1.0.2"
-      }
-    },
-    "foreachasync": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
-      "integrity": "sha1-VQKYfchxS+M5IJfzLgBxyd7gfPY=",
-      "dev": true
-    },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true
-    },
-    "form-data": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-      "dev": true,
-      "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.6",
-        "mime-types": "2.1.18"
-      }
-    },
-    "formatio": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
-      "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
-      "dev": true,
-      "requires": {
-        "samsam": "1.3.0"
-      }
-    },
-    "fragment-cache": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
-      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
-      "dev": true,
-      "requires": {
-        "map-cache": "0.2.2"
-      }
-    },
-    "from2": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
-      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6"
-      }
-    },
-    "fs-extra": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
-      "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "4.0.0",
-        "universalify": "0.1.1"
-      }
-    },
-    "fs-minipass": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "minipass": "2.2.4"
-      }
-    },
-    "fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-    },
-    "fsevents": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.0.tgz",
-      "integrity": "sha512-ROrBIbmw4ulxmQTwYAAGyN/0xgIOAFd6gX/K3F1aGLP/K5KxkubrlGISMV5EEWEB7qtiEdE0HpaqvMMHR+Ib6w==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "nan": "2.10.0",
-        "node-pre-gyp": "0.9.1"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
         },
         "ajv": {
-          "version": "4.11.8",
-          "bundled": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
+            "version": "5.5.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+            "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+            "dev": true,
+            "requires": {
+                "co": "4.6.0",
+                "fast-deep-equal": "1.1.0",
+                "fast-json-stable-stringify": "2.0.0",
+                "json-schema-traverse": "0.3.1"
+            }
+        },
+        "ajv-keywords": {
+            "version": "2.1.1",
+            "resolved":
+                "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+            "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+            "dev": true
+        },
+        "align-text": {
+            "version": "0.1.4",
+            "resolved":
+                "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+            "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+            "dev": true,
+            "requires": {
+                "kind-of": "3.2.2",
+                "longest": "1.0.1",
+                "repeat-string": "1.6.1"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved":
+                        "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
+        "amdefine": {
+            "version": "1.0.1",
+            "resolved":
+                "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+            "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+            "dev": true
+        },
+        "ansi-escapes": {
+            "version": "3.1.0",
+            "resolved":
+                "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+            "integrity":
+                "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
         },
         "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
+            "version": "3.0.0",
+            "resolved":
+                "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+            "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
-        "aproba": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+        "ansi-styles": {
+            "version": "3.2.1",
+            "resolved":
+                "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity":
+                "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "requires": {
+                "color-convert": "1.9.1"
+            }
         },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.2.9"
-          }
+        "ansicolors": {
+            "version": "0.2.1",
+            "resolved":
+                "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
+            "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8=",
+            "dev": true
+        },
+        "any-observable": {
+            "version": "0.2.0",
+            "resolved":
+                "https://registry.npmjs.org/any-observable/-/any-observable-0.2.0.tgz",
+            "integrity": "sha1-xnhwBYADV5AJCD9UrAq6+1wz0kI=",
+            "dev": true
+        },
+        "anymatch": {
+            "version": "2.0.0",
+            "resolved":
+                "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+            "integrity":
+                "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+            "dev": true,
+            "requires": {
+                "micromatch": "3.1.10",
+                "normalize-path": "2.1.1"
+            }
+        },
+        "app-root-path": {
+            "version": "2.0.1",
+            "resolved":
+                "https://registry.npmjs.org/app-root-path/-/app-root-path-2.0.1.tgz",
+            "integrity": "sha1-zWLc+OT9WkF+/GZNLlsQZTxlG0Y=",
+            "dev": true
+        },
+        "append-transform": {
+            "version": "0.4.0",
+            "resolved":
+                "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
+            "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+            "dev": true,
+            "requires": {
+                "default-require-extensions": "1.0.0"
+            }
+        },
+        "argparse": {
+            "version": "1.0.10",
+            "resolved":
+                "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity":
+                "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "requires": {
+                "sprintf-js": "1.0.3"
+            }
+        },
+        "argv-formatter": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/argv-formatter/-/argv-formatter-1.0.0.tgz",
+            "integrity": "sha1-oMoMvCmltz6Dbuvhy/bF4OTrgvk=",
+            "dev": true
+        },
+        "arr-diff": {
+            "version": "4.0.0",
+            "resolved":
+                "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+            "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+        },
+        "arr-flatten": {
+            "version": "1.1.0",
+            "resolved":
+                "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+            "integrity":
+                "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+        },
+        "arr-union": {
+            "version": "3.1.0",
+            "resolved":
+                "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+            "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+        },
+        "array-differ": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+            "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
+        },
+        "array-equal": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+            "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+            "dev": true
+        },
+        "array-find-index": {
+            "version": "1.0.2",
+            "resolved":
+                "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+            "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+            "dev": true
+        },
+        "array-ify": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+            "integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
+            "dev": true
+        },
+        "array-union": {
+            "version": "1.0.2",
+            "resolved":
+                "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+            "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+            "requires": {
+                "array-uniq": "1.0.3"
+            }
+        },
+        "array-uniq": {
+            "version": "1.0.3",
+            "resolved":
+                "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+        },
+        "array-unique": {
+            "version": "0.3.2",
+            "resolved":
+                "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+            "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+        },
+        "arrify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+            "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
         },
         "asn1": {
-          "version": "0.2.3",
-          "bundled": true
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+            "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+            "dev": true
         },
         "assert-plus": {
-          "version": "0.2.0",
-          "bundled": true
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+            "dev": true
+        },
+        "assign-symbols": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+            "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+        },
+        "astral-regex": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+            "integrity":
+                "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+            "dev": true
+        },
+        "async": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+            "integrity":
+                "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+            "requires": {
+                "lodash": "4.17.10"
+            }
+        },
+        "async-limiter": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+            "integrity":
+                "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+            "dev": true
         },
         "asynckit": {
-          "version": "0.4.0",
-          "bundled": true
+            "version": "0.4.0",
+            "resolved":
+                "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+            "dev": true
+        },
+        "atob": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
+            "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio="
         },
         "aws-sign2": {
-          "version": "0.6.0",
-          "bundled": true
+            "version": "0.7.0",
+            "resolved":
+                "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+            "dev": true
         },
         "aws4": {
-          "version": "1.6.0",
-          "bundled": true
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+            "integrity":
+                "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
+            "dev": true
+        },
+        "babel-code-frame": {
+            "version": "6.26.0",
+            "resolved":
+                "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+            "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+            "dev": true,
+            "requires": {
+                "chalk": "1.1.3",
+                "esutils": "2.0.2",
+                "js-tokens": "3.0.2"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved":
+                        "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved":
+                        "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved":
+                        "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                }
+            }
+        },
+        "babel-core": {
+            "version": "6.26.3",
+            "resolved":
+                "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+            "integrity":
+                "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+            "dev": true,
+            "requires": {
+                "babel-code-frame": "6.26.0",
+                "babel-generator": "6.26.1",
+                "babel-helpers": "6.24.1",
+                "babel-messages": "6.23.0",
+                "babel-register": "6.26.0",
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0",
+                "convert-source-map": "1.5.1",
+                "debug": "2.6.9",
+                "json5": "0.5.1",
+                "lodash": "4.17.10",
+                "minimatch": "3.0.4",
+                "path-is-absolute": "1.0.1",
+                "private": "0.1.8",
+                "slash": "1.0.0",
+                "source-map": "0.5.7"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved":
+                        "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity":
+                        "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
+            }
+        },
+        "babel-generator": {
+            "version": "6.26.1",
+            "resolved":
+                "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+            "integrity":
+                "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+            "dev": true,
+            "requires": {
+                "babel-messages": "6.23.0",
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0",
+                "detect-indent": "4.0.0",
+                "jsesc": "1.3.0",
+                "lodash": "4.17.10",
+                "source-map": "0.5.7",
+                "trim-right": "1.0.1"
+            }
+        },
+        "babel-helpers": {
+            "version": "6.24.1",
+            "resolved":
+                "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+            "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+            "dev": true,
+            "requires": {
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0"
+            }
+        },
+        "babel-jest": {
+            "version": "22.4.3",
+            "resolved":
+                "https://registry.npmjs.org/babel-jest/-/babel-jest-22.4.3.tgz",
+            "integrity":
+                "sha512-BgSjmtl3mW3i+VeVHEr9d2zFSAT66G++pJcHQiUjd00pkW+voYXFctIm/indcqOWWXw5a1nUpR1XWszD9fJ1qg==",
+            "dev": true,
+            "requires": {
+                "babel-plugin-istanbul": "4.1.6",
+                "babel-preset-jest": "22.4.3"
+            }
+        },
+        "babel-messages": {
+            "version": "6.23.0",
+            "resolved":
+                "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+            "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+            "dev": true,
+            "requires": {
+                "babel-runtime": "6.26.0"
+            }
+        },
+        "babel-plugin-istanbul": {
+            "version": "4.1.6",
+            "resolved":
+                "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
+            "integrity":
+                "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
+            "dev": true,
+            "requires": {
+                "babel-plugin-syntax-object-rest-spread": "6.13.0",
+                "find-up": "2.1.0",
+                "istanbul-lib-instrument": "1.10.1",
+                "test-exclude": "4.2.1"
+            }
+        },
+        "babel-plugin-jest-hoist": {
+            "version": "22.4.3",
+            "resolved":
+                "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.3.tgz",
+            "integrity":
+                "sha512-zhvv4f6OTWy2bYevcJftwGCWXMFe7pqoz41IhMi4xna7xNsX5NygdagsrE0y6kkfuXq8UalwvPwKTyAxME2E/g==",
+            "dev": true
+        },
+        "babel-plugin-syntax-object-rest-spread": {
+            "version": "6.13.0",
+            "resolved":
+                "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+            "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+            "dev": true
+        },
+        "babel-preset-jest": {
+            "version": "22.4.3",
+            "resolved":
+                "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.4.3.tgz",
+            "integrity":
+                "sha512-a+M3LTEXTq3gxv0uBN9Qm6ahUl7a8pj923nFbCUdqFUSsf3YrX8Uc+C3MEwji5Af3LiQjSC7w4ooYewlz8HRTA==",
+            "dev": true,
+            "requires": {
+                "babel-plugin-jest-hoist": "22.4.3",
+                "babel-plugin-syntax-object-rest-spread": "6.13.0"
+            }
+        },
+        "babel-register": {
+            "version": "6.26.0",
+            "resolved":
+                "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+            "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+            "dev": true,
+            "requires": {
+                "babel-core": "6.26.3",
+                "babel-runtime": "6.26.0",
+                "core-js": "2.5.6",
+                "home-or-tmp": "2.0.0",
+                "lodash": "4.17.10",
+                "mkdirp": "0.5.1",
+                "source-map-support": "0.4.18"
+            },
+            "dependencies": {
+                "source-map-support": {
+                    "version": "0.4.18",
+                    "resolved":
+                        "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+                    "integrity":
+                        "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+                    "dev": true,
+                    "requires": {
+                        "source-map": "0.5.7"
+                    }
+                }
+            }
+        },
+        "babel-runtime": {
+            "version": "6.26.0",
+            "resolved":
+                "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+            "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+            "dev": true,
+            "requires": {
+                "core-js": "2.5.6",
+                "regenerator-runtime": "0.11.1"
+            }
+        },
+        "babel-template": {
+            "version": "6.26.0",
+            "resolved":
+                "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+            "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+            "dev": true,
+            "requires": {
+                "babel-runtime": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0",
+                "lodash": "4.17.10"
+            }
+        },
+        "babel-traverse": {
+            "version": "6.26.0",
+            "resolved":
+                "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+            "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+            "dev": true,
+            "requires": {
+                "babel-code-frame": "6.26.0",
+                "babel-messages": "6.23.0",
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0",
+                "debug": "2.6.9",
+                "globals": "9.18.0",
+                "invariant": "2.2.4",
+                "lodash": "4.17.10"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved":
+                        "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity":
+                        "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "globals": {
+                    "version": "9.18.0",
+                    "resolved":
+                        "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+                    "integrity":
+                        "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+                    "dev": true
+                }
+            }
+        },
+        "babel-types": {
+            "version": "6.26.0",
+            "resolved":
+                "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+            "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+            "dev": true,
+            "requires": {
+                "babel-runtime": "6.26.0",
+                "esutils": "2.0.2",
+                "lodash": "4.17.10",
+                "to-fast-properties": "1.0.3"
+            }
+        },
+        "babylon": {
+            "version": "6.18.0",
+            "resolved":
+                "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+            "integrity":
+                "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+            "dev": true
         },
         "balanced-match": {
-          "version": "0.4.2",
-          "bundled": true
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+        },
+        "base": {
+            "version": "0.11.2",
+            "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+            "integrity":
+                "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+            "requires": {
+                "cache-base": "1.0.1",
+                "class-utils": "0.3.6",
+                "component-emitter": "1.2.1",
+                "define-property": "1.0.0",
+                "isobject": "3.0.1",
+                "mixin-deep": "1.3.1",
+                "pascalcase": "0.1.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "requires": {
+                        "is-descriptor": "1.0.2"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity":
+                        "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "requires": {
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity":
+                        "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "requires": {
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved":
+                        "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity":
+                        "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "requires": {
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
+                    }
+                }
+            }
         },
         "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
+            "version": "1.0.1",
+            "resolved":
+                "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+            "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "tweetnacl": "0.14.5"
+            }
         },
-        "block-stream": {
-          "version": "0.0.9",
-          "bundled": true,
-          "requires": {
-            "inherits": "2.0.3"
-          }
+        "before-after-hook": {
+            "version": "1.1.0",
+            "resolved":
+                "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.1.0.tgz",
+            "integrity":
+                "sha512-VOMDtYPwLbIncTxNoSzRyvaMxtXmLWLUqr8k5AfC1BzLk34HvBXaQX8snOwQZ4c0aX8aSERqtJSiI9/m2u5kuA==",
+            "dev": true
+        },
+        "binaryextensions": {
+            "version": "2.1.1",
+            "resolved":
+                "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.1.1.tgz",
+            "integrity":
+                "sha512-XBaoWE9RW8pPdPQNibZsW2zh8TW6gcarXp1FZPwT8Uop8ScSNldJEWf2k9l3HeTqdrEwsOsFcq74RiJECW34yA=="
         },
         "boom": {
-          "version": "2.10.1",
-          "bundled": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+            "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+            "dev": true,
+            "requires": {
+                "hoek": "4.2.1"
+            }
+        },
+        "bottleneck": {
+            "version": "2.3.0",
+            "resolved":
+                "https://registry.npmjs.org/bottleneck/-/bottleneck-2.3.0.tgz",
+            "integrity":
+                "sha512-Zxhe8FRIiFp5/uGRxIt/s26f6bm0Z87BWzPbUUZZGLkXOldRse1I/pqASYKjcth+6D1NOpVjaqD1X6aEqH+GCw==",
+            "dev": true
         },
         "brace-expansion": {
-          "version": "1.1.7",
-          "bundled": true,
-          "requires": {
-            "balanced-match": "0.4.2",
-            "concat-map": "0.0.1"
-          }
-        },
-        "buffer-shims": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true
-        },
-        "co": {
-          "version": "4.6.0",
-          "bundled": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "bundled": true,
-          "requires": {
-            "boom": "2.10.1"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
+            "version": "1.1.11",
+            "resolved":
+                "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity":
+                "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "requires": {
+                "balanced-match": "1.0.0",
+                "concat-map": "0.0.1"
             }
-          }
         },
-        "debug": {
-          "version": "2.6.8",
-          "bundled": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-extend": {
-          "version": "0.4.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "detect-libc": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "extend": {
-          "version": "3.0.1",
-          "bundled": true
-        },
-        "extsprintf": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "bundled": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "fstream": {
-          "version": "1.0.11",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
-          }
-        },
-        "fstream-ignore": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
-          }
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aproba": "1.1.1",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
-          }
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "bundled": true,
-          "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "bundled": true,
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "bundled": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.0",
-            "sshpk": "1.13.0"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "ini": {
-          "version": "1.3.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true
-        },
-        "jodid25519": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "jsonify": "0.0.0"
-          }
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "bundled": true
-        },
-        "jsprim": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.0.2",
-            "json-schema": "0.2.3",
-            "verror": "1.3.6"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "mime-db": {
-          "version": "1.27.0",
-          "bundled": true
-        },
-        "mime-types": {
-          "version": "2.1.15",
-          "bundled": true,
-          "requires": {
-            "mime-db": "1.27.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "requires": {
-            "brace-expansion": "1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "node-pre-gyp": {
-          "version": "0.9.1",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.9.1.tgz",
-          "integrity": "sha1-8RwHUW3ZL4cZnbx+GDjqt81WyeA=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "detect-libc": "1.0.2",
-            "mkdirp": "0.5.1",
-            "needle": "2.2.0",
-            "nopt": "4.0.1",
-            "npm-packlist": "1.1.10",
-            "npmlog": "4.1.0",
-            "rc": "1.2.1",
-            "rimraf": "2.6.1",
-            "semver": "5.3.0",
-            "tar": "4.4.1"
-          },
-          "dependencies": {
-            "safe-buffer": {
-              "version": "5.1.1",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-              "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-              "dev": true,
-              "optional": true
+        "braces": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+            "integrity":
+                "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+            "requires": {
+                "arr-flatten": "1.1.0",
+                "array-unique": "0.3.2",
+                "extend-shallow": "2.0.1",
+                "fill-range": "4.0.0",
+                "isobject": "3.0.1",
+                "repeat-element": "1.1.2",
+                "snapdragon": "0.8.2",
+                "snapdragon-node": "2.1.1",
+                "split-string": "3.1.0",
+                "to-regex": "3.0.2"
             },
-            "tar": {
-              "version": "4.4.1",
-              "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
-              "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "chownr": "1.0.1",
-                "fs-minipass": "1.2.5",
-                "minipass": "2.2.4",
-                "minizlib": "1.1.0",
-                "mkdirp": "0.5.1",
-                "safe-buffer": "5.1.1",
-                "yallist": "3.0.2"
-              }
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "requires": {
+                        "is-extendable": "0.1.1"
+                    }
+                }
             }
-          }
         },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
-          }
+        "browser-process-hrtime": {
+            "version": "0.1.2",
+            "resolved":
+                "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
+            "integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44=",
+            "dev": true
         },
-        "npmlog": {
-          "version": "4.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "bundled": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "bundled": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "bundled": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true
-        },
-        "qs": {
-          "version": "6.4.0",
-          "bundled": true
-        },
-        "rc": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+        "browser-resolve": {
+            "version": "1.11.2",
+            "resolved":
+                "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
+            "integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
+            "dev": true,
+            "requires": {
+                "resolve": "1.1.7"
+            },
+            "dependencies": {
+                "resolve": {
+                    "version": "1.1.7",
+                    "resolved":
+                        "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+                    "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+                    "dev": true
+                }
             }
-          }
         },
-        "readable-stream": {
-          "version": "2.2.9",
-          "bundled": true,
-          "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.1",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "request": {
-          "version": "2.81.0",
-          "bundled": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.0.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.1",
-          "bundled": true,
-          "requires": {
-            "glob": "7.1.2"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.0.1",
-          "bundled": true
-        },
-        "semver": {
-          "version": "5.3.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "bundled": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "sshpk": {
-          "version": "1.13.0",
-          "bundled": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jodid25519": "1.0.2",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
+        "bser": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
+            "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+            "dev": true,
+            "requires": {
+                "node-int64": "0.4.0"
             }
-          }
         },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
+        "btoa-lite": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
+            "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc=",
+            "dev": true
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
+        "buffer-from": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+            "integrity":
+                "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
+            "dev": true
         },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true
+        "builtin-modules": {
+            "version": "1.1.1",
+            "resolved":
+                "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+            "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
         },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
+        "cache-base": {
+            "version": "1.0.1",
+            "resolved":
+                "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+            "integrity":
+                "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+            "requires": {
+                "collection-visit": "1.0.0",
+                "component-emitter": "1.2.1",
+                "get-value": "2.0.6",
+                "has-value": "1.0.0",
+                "isobject": "3.0.1",
+                "set-value": "2.0.0",
+                "to-object-path": "0.3.0",
+                "union-value": "1.0.0",
+                "unset-value": "1.0.0"
+            }
         },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+        "cachedir": {
+            "version": "1.2.0",
+            "resolved":
+                "https://registry.npmjs.org/cachedir/-/cachedir-1.2.0.tgz",
+            "integrity":
+                "sha512-i3xIKd9U4ov0hWXYo08oJy0YVz0krZ9dbTZQim41xkg0IiScptkAK0UilZ5M1WE3gnWjXAa9+cMtrJ5dM+THbA==",
+            "dev": true,
+            "requires": {
+                "os-homedir": "1.0.2"
+            }
         },
-        "tar": {
-          "version": "2.2.1",
-          "bundled": true,
-          "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
-          }
+        "call-me-maybe": {
+            "version": "1.0.1",
+            "resolved":
+                "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+            "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
         },
-        "tar-pack": {
-          "version": "3.4.0",
-          "bundled": true,
-          "requires": {
-            "debug": "2.6.8",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.2.9",
-            "rimraf": "2.6.1",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
-          }
+        "caller-path": {
+            "version": "0.1.0",
+            "resolved":
+                "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+            "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+            "dev": true,
+            "requires": {
+                "callsites": "0.2.0"
+            }
         },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "bundled": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
+        "callsites": {
+            "version": "0.2.0",
+            "resolved":
+                "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+            "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+            "dev": true
         },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "optional": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "bundled": true
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "uuid": {
-          "version": "3.0.1",
-          "bundled": true
-        },
-        "verror": {
-          "version": "1.3.6",
-          "bundled": true,
-          "requires": {
-            "extsprintf": "1.0.2"
-          }
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "string-width": "1.0.2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "yallist": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true,
-          "optional": true
-        }
-      }
-    },
-    "functional-red-black-tree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-      "dev": true
-    },
-    "gauge": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-      "dev": true,
-      "requires": {
-        "aproba": "1.2.0",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        }
-      }
-    },
-    "generate-function": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-      "dev": true
-    },
-    "generate-object-property": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true,
-      "requires": {
-        "is-property": "1.0.2"
-      }
-    },
-    "get-caller-file": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
-      "dev": true
-    },
-    "get-own-enumerable-property-symbols": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz",
-      "integrity": "sha512-TtY/sbOemiMKPRUDDanGCSgBYe7Mf0vbRsWnBZ+9yghpZ1MvcpSpuZFjHdEeY/LZjZy0vdLjS77L6HosisFiug==",
-      "dev": true
-    },
-    "get-pkg-repo": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-1.4.0.tgz",
-      "integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
-      "dev": true,
-      "requires": {
-        "hosted-git-info": "2.6.0",
-        "meow": "3.7.0",
-        "normalize-package-data": "2.4.0",
-        "parse-github-repo-url": "1.4.1",
-        "through2": "2.0.3"
-      },
-      "dependencies": {
         "camelcase": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-          "dev": true
+            "version": "1.2.1",
+            "resolved":
+                "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+            "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+            "dev": true,
+            "optional": true
         },
         "camelcase-keys": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-          "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-          "dev": true,
-          "requires": {
-            "camelcase": "2.1.1",
-            "map-obj": "1.0.1"
-          }
-        },
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
-          }
-        },
-        "map-obj": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-          "dev": true
-        },
-        "meow": {
-          "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-          "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-          "dev": true,
-          "requires": {
-            "camelcase-keys": "2.1.0",
-            "decamelize": "1.2.0",
-            "loud-rejection": "1.6.0",
-            "map-obj": "1.0.1",
-            "minimist": "1.2.0",
-            "normalize-package-data": "2.4.0",
-            "object-assign": "4.1.1",
-            "read-pkg-up": "1.0.1",
-            "redent": "1.0.0",
-            "trim-newlines": "1.0.0"
-          }
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "1.3.1"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "dev": true,
-          "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
-          }
-        },
-        "redent": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-          "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-          "dev": true,
-          "requires": {
-            "indent-string": "2.1.0",
-            "strip-indent": "1.0.1"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
-        },
-        "strip-indent": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-          "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "4.0.1"
-          }
-        },
-        "trim-newlines": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-          "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-          "dev": true
-        }
-      }
-    },
-    "get-stdin": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
-    },
-    "get-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
-    },
-    "get-value": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
-      "dev": true
-    },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
-      }
-    },
-    "gh-got": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/gh-got/-/gh-got-6.0.0.tgz",
-      "integrity": "sha512-F/mS+fsWQMo1zfgG9MD8KWvTWPPzzhuVwY++fhQ5Ggd+0P+CAMHtzMZhNxG+TqGfHDChJKsbh6otfMGqO2AKBw==",
-      "requires": {
-        "got": "7.1.0",
-        "is-plain-obj": "1.1.0"
-      }
-    },
-    "git-head": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/git-head/-/git-head-1.20.1.tgz",
-      "integrity": "sha1-A20WpLN0lJ5OPa8VgnkDaG08zVI=",
-      "dev": true,
-      "requires": {
-        "git-refs": "1.1.3"
-      }
-    },
-    "git-raw-commits": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.6.tgz",
-      "integrity": "sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==",
-      "dev": true,
-      "requires": {
-        "dargs": "4.1.0",
-        "lodash.template": "4.4.0",
-        "meow": "4.0.0",
-        "split2": "2.2.0",
-        "through2": "2.0.3"
-      },
-      "dependencies": {
-        "dargs": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
-          "integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        }
-      }
-    },
-    "git-refs": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/git-refs/-/git-refs-1.1.3.tgz",
-      "integrity": "sha1-gwl8s6klhcSkkm7FTiGC354g6J0=",
-      "dev": true,
-      "requires": {
-        "path-object": "2.3.0",
-        "slash": "1.0.0",
-        "walk": "2.3.13"
-      }
-    },
-    "git-remote-origin-url": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
-      "integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
-      "dev": true,
-      "requires": {
-        "gitconfiglocal": "1.0.0",
-        "pify": "2.3.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        }
-      }
-    },
-    "git-semver-tags": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.3.6.tgz",
-      "integrity": "sha512-2jHlJnln4D/ECk9FxGEBh3k44wgYdWjWDtMmJPaecjoRmxKo3Y1Lh8GMYuOPu04CHw86NTAODchYjC5pnpMQig==",
-      "dev": true,
-      "requires": {
-        "meow": "4.0.0",
-        "semver": "5.5.0"
-      }
-    },
-    "gitconfiglocal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
-      "integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
-      "dev": true,
-      "requires": {
-        "ini": "1.3.5"
-      }
-    },
-    "github": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/github/-/github-12.1.0.tgz",
-      "integrity": "sha512-HhWjhd/OATC4Hjj7xfGjGRtwWzo/fzTc55EkvsRatI9G6Vp47mVcdBIt1lQ56A9Qit/yVQRX1+M9jbWlcJvgug==",
-      "dev": true,
-      "requires": {
-        "dotenv": "4.0.0",
-        "follow-redirects": "1.2.6",
-        "https-proxy-agent": "2.2.1",
-        "lodash": "4.17.5",
-        "mime": "2.3.1",
-        "netrc": "0.1.4"
-      }
-    },
-    "github-username": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/github-username/-/github-username-4.1.0.tgz",
-      "integrity": "sha1-y+KABBiDIG2kISrp5LXxacML9Bc=",
-      "requires": {
-        "gh-got": "6.0.0"
-      }
-    },
-    "glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
-      }
-    },
-    "glob-base": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "dev": true,
-      "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
-      }
-    },
-    "glob-parent": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "dev": true,
-      "requires": {
-        "is-glob": "2.0.1"
-      }
-    },
-    "globals": {
-      "version": "11.4.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.4.0.tgz",
-      "integrity": "sha512-Dyzmifil8n/TmSqYDEXbm+C8yitzJQqQIlJQLNRMwa+BOUJpRC19pyVeN12JAjt61xonvXjtff+hJruTRXn5HA==",
-      "dev": true
-    },
-    "globby": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-      "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-      "requires": {
-        "array-union": "1.0.2",
-        "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-        }
-      }
-    },
-    "got": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
-      "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
-      "requires": {
-        "decompress-response": "3.3.0",
-        "duplexer3": "0.1.4",
-        "get-stream": "3.0.0",
-        "is-plain-obj": "1.1.0",
-        "is-retry-allowed": "1.1.0",
-        "is-stream": "1.1.0",
-        "isurl": "1.0.0",
-        "lowercase-keys": "1.0.1",
-        "p-cancelable": "0.3.0",
-        "p-timeout": "1.2.1",
-        "safe-buffer": "5.1.1",
-        "timed-out": "4.0.1",
-        "url-parse-lax": "1.0.0",
-        "url-to-options": "1.0.1"
-      }
-    },
-    "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-    },
-    "grouped-queue": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/grouped-queue/-/grouped-queue-0.3.3.tgz",
-      "integrity": "sha1-wWfSpTGcWg4JZO9qJbfC34mWyFw=",
-      "requires": {
-        "lodash": "4.17.5"
-      }
-    },
-    "growly": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-      "dev": true
-    },
-    "handlebars": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
-      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
-      "dev": true,
-      "requires": {
-        "async": "1.5.2",
-        "optimist": "0.6.1",
-        "source-map": "0.4.4",
-        "uglify-js": "2.8.29"
-      },
-      "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
-        }
-      }
-    },
-    "har-validator": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-      "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-      "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "commander": "2.15.1",
-        "is-my-json-valid": "2.17.2",
-        "pinkie-promise": "2.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
-      }
-    },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "requires": {
-        "ansi-regex": "2.1.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        }
-      }
-    },
-    "has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-    },
-    "has-symbol-support-x": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
-      "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
-    },
-    "has-to-string-tag-x": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
-      "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
-      "requires": {
-        "has-symbol-support-x": "1.4.2"
-      }
-    },
-    "has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-      "dev": true
-    },
-    "has-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
-      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
-      "dev": true,
-      "requires": {
-        "get-value": "2.0.6",
-        "has-values": "1.0.0",
-        "isobject": "3.0.1"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        }
-      }
-    },
-    "has-values": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
-      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
-      "dev": true,
-      "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
+            "version": "4.2.0",
+            "resolved":
+                "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+            "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+            "dev": true,
+            "requires": {
+                "camelcase": "4.1.0",
+                "map-obj": "2.0.0",
+                "quick-lru": "1.1.0"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "4.1.0",
+                    "resolved":
+                        "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                    "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+                    "dev": true
+                }
             }
-          }
         },
-        "kind-of": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "1.1.6"
-          }
-        }
-      }
-    },
-    "hawk": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "dev": true,
-      "requires": {
-        "boom": "2.10.1",
-        "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
-        "sntp": "1.0.9"
-      }
-    },
-    "hoek": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true
-    },
-    "home-or-tmp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-      "dev": true,
-      "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
-      }
-    },
-    "hosted-git-info": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
-      "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
-    },
-    "html-encoding-sniffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
-      "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
-      "dev": true,
-      "requires": {
-        "whatwg-encoding": "1.0.3"
-      }
-    },
-    "http-cache-semantics": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
-      "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
-      "dev": true
-    },
-    "http-signature": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "0.2.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.14.1"
-      }
-    },
-    "https-proxy-agent": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
-      "dev": true,
-      "requires": {
-        "agent-base": "4.2.0",
-        "debug": "3.1.0"
-      }
-    },
-    "husky": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
-      "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
-      "dev": true,
-      "requires": {
-        "is-ci": "1.1.0",
-        "normalize-path": "1.0.0",
-        "strip-indent": "2.0.0"
-      }
-    },
-    "iconv-lite": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
-      "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
-      "requires": {
-        "safer-buffer": "2.1.2"
-      }
-    },
-    "ignore": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
-      "dev": true
-    },
-    "ignore-walk": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
-      "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "minimatch": "3.0.4"
-      }
-    },
-    "import-from": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/import-from/-/import-from-2.1.0.tgz",
-      "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
-      "dev": true,
-      "requires": {
-        "resolve-from": "3.0.0"
-      },
-      "dependencies": {
-        "resolve-from": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
-          "dev": true
-        }
-      }
-    },
-    "imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "dev": true
-    },
-    "indent-string": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-      "dev": true,
-      "requires": {
-        "repeating": "2.0.1"
-      }
-    },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
-      }
-    },
-    "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-    },
-    "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-      "dev": true
-    },
-    "inquirer": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
-      "requires": {
-        "ansi-escapes": "3.1.0",
-        "chalk": "2.4.0",
-        "cli-cursor": "2.1.0",
-        "cli-width": "2.2.0",
-        "external-editor": "2.2.0",
-        "figures": "2.0.0",
-        "lodash": "4.17.5",
-        "mute-stream": "0.0.7",
-        "run-async": "2.3.0",
-        "rx-lite": "4.0.8",
-        "rx-lite-aggregates": "4.0.8",
-        "string-width": "2.1.1",
-        "strip-ansi": "4.0.0",
-        "through": "2.3.8"
-      }
-    },
-    "interpret": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
-      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
-    },
-    "into-stream": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
-      "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
-      "dev": true,
-      "requires": {
-        "from2": "2.3.0",
-        "p-is-promise": "1.1.0"
-      }
-    },
-    "invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "1.3.1"
-      }
-    },
-    "invert-kv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-      "dev": true
-    },
-    "is-accessor-descriptor": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-      "dev": true,
-      "requires": {
-        "kind-of": "3.2.2"
-      }
-    },
-    "is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
-    },
-    "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
-    },
-    "is-builtin-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "requires": {
-        "builtin-modules": "1.1.1"
-      }
-    },
-    "is-ci": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
-      "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
-      "dev": true,
-      "requires": {
-        "ci-info": "1.1.3"
-      }
-    },
-    "is-data-descriptor": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-      "dev": true,
-      "requires": {
-        "kind-of": "3.2.2"
-      }
-    },
-    "is-descriptor": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-      "dev": true,
-      "requires": {
-        "is-accessor-descriptor": "0.1.6",
-        "is-data-descriptor": "0.1.4",
-        "kind-of": "5.1.0"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-          "dev": true
-        }
-      }
-    },
-    "is-dotfile": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-      "dev": true
-    },
-    "is-equal-shallow": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "dev": true,
-      "requires": {
-        "is-primitive": "2.0.0"
-      }
-    },
-    "is-extendable": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-      "dev": true
-    },
-    "is-extglob": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-      "dev": true
-    },
-    "is-finite": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "1.0.1"
-      }
-    },
-    "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-    },
-    "is-glob": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-      "dev": true,
-      "requires": {
-        "is-extglob": "1.0.0"
-      }
-    },
-    "is-my-ip-valid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
-      "dev": true
-    },
-    "is-my-json-valid": {
-      "version": "2.17.2",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
-      "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
-      "dev": true,
-      "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "is-my-ip-valid": "1.0.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
-      }
-    },
-    "is-number": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-      "dev": true,
-      "requires": {
-        "kind-of": "3.2.2"
-      }
-    },
-    "is-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-      "dev": true
-    },
-    "is-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
-    },
-    "is-odd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
-      "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
-      "dev": true,
-      "requires": {
-        "is-number": "4.0.0"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-          "dev": true
-        }
-      }
-    },
-    "is-path-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
-      "dev": true
-    },
-    "is-path-in-cwd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
-      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
-      "dev": true,
-      "requires": {
-        "is-path-inside": "1.0.1"
-      }
-    },
-    "is-path-inside": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-      "dev": true,
-      "requires": {
-        "path-is-inside": "1.0.2"
-      }
-    },
-    "is-plain-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
-    },
-    "is-plain-object": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "dev": true,
-      "requires": {
-        "isobject": "3.0.1"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        }
-      }
-    },
-    "is-posix-bracket": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-      "dev": true
-    },
-    "is-primitive": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-      "dev": true
-    },
-    "is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
-    },
-    "is-property": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-      "dev": true
-    },
-    "is-redirect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
-      "dev": true
-    },
-    "is-regexp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
-      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
-      "dev": true
-    },
-    "is-resolvable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
-      "dev": true
-    },
-    "is-retry-allowed": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
-    },
-    "is-scoped": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-scoped/-/is-scoped-1.0.0.tgz",
-      "integrity": "sha1-RJypgpnnEwOCViieyytUDcQ3yzA=",
-      "requires": {
-        "scoped-regex": "1.0.0"
-      }
-    },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
-    "is-subset": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-      "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
-      "dev": true
-    },
-    "is-text-path": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
-      "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
-      "dev": true,
-      "requires": {
-        "text-extensions": "1.7.0"
-      }
-    },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
-    },
-    "is-utf8": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
-    },
-    "is-windows": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-      "dev": true
-    },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-    },
-    "isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-    },
-    "isobject": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-      "dev": true,
-      "requires": {
-        "isarray": "1.0.0"
-      }
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
-    },
-    "istanbul-api": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.3.1.tgz",
-      "integrity": "sha512-duj6AlLcsWNwUpfyfHt0nWIeRiZpuShnP40YTxOGQgtaN8fd6JYSxsvxUphTDy8V5MfDXo4s/xVCIIvVCO808g==",
-      "dev": true,
-      "requires": {
-        "async": "2.6.0",
-        "compare-versions": "3.1.0",
-        "fileset": "2.0.3",
-        "istanbul-lib-coverage": "1.2.0",
-        "istanbul-lib-hook": "1.2.0",
-        "istanbul-lib-instrument": "1.10.1",
-        "istanbul-lib-report": "1.1.4",
-        "istanbul-lib-source-maps": "1.2.4",
-        "istanbul-reports": "1.3.0",
-        "js-yaml": "3.11.0",
-        "mkdirp": "0.5.1",
-        "once": "1.4.0"
-      },
-      "dependencies": {
-        "istanbul-lib-source-maps": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.4.tgz",
-          "integrity": "sha512-UzuK0g1wyQijiaYQxj/CdNycFhAd2TLtO2obKQMTZrZ1jzEMRY3rvpASEKkaxbRR6brvdovfA03znPa/pXcejg==",
-          "dev": true,
-          "requires": {
-            "debug": "3.1.0",
-            "istanbul-lib-coverage": "1.2.0",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.2",
-            "source-map": "0.5.7"
-          }
-        }
-      }
-    },
-    "istanbul-lib-coverage": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz",
-      "integrity": "sha512-GvgM/uXRwm+gLlvkWHTjDAvwynZkL9ns15calTrmhGgowlwJBbWMYzWbKqE2DT6JDP1AFXKa+Zi0EkqNCUqY0A==",
-      "dev": true
-    },
-    "istanbul-lib-hook": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.0.tgz",
-      "integrity": "sha512-p3En6/oGkFQV55Up8ZPC2oLxvgSxD8CzA0yBrhRZSh3pfv3OFj9aSGVC0yoerAi/O4u7jUVnOGVX1eVFM+0tmQ==",
-      "dev": true,
-      "requires": {
-        "append-transform": "0.4.0"
-      }
-    },
-    "istanbul-lib-instrument": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz",
-      "integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
-      "dev": true,
-      "requires": {
-        "babel-generator": "6.26.1",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "istanbul-lib-coverage": "1.2.0",
-        "semver": "5.5.0"
-      }
-    },
-    "istanbul-lib-report": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.4.tgz",
-      "integrity": "sha512-Azqvq5tT0U09nrncK3q82e/Zjkxa4tkFZv7E6VcqP0QCPn6oNljDPfrZEC/umNXds2t7b8sRJfs6Kmpzt8m2kA==",
-      "dev": true,
-      "requires": {
-        "istanbul-lib-coverage": "1.2.0",
-        "mkdirp": "0.5.1",
-        "path-parse": "1.0.5",
-        "supports-color": "3.2.3"
-      },
-      "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
+        "capture-exit": {
+            "version": "1.2.0",
+            "resolved":
+                "https://registry.npmjs.org/capture-exit/-/capture-exit-1.2.0.tgz",
+            "integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
+            "dev": true,
+            "requires": {
+                "rsvp": "3.6.2"
+            }
         },
-        "supports-color": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true,
-          "requires": {
-            "has-flag": "1.0.0"
-          }
-        }
-      }
-    },
-    "istanbul-lib-source-maps": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz",
-      "integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
-      "dev": true,
-      "requires": {
-        "debug": "3.1.0",
-        "istanbul-lib-coverage": "1.2.0",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2",
-        "source-map": "0.5.7"
-      }
-    },
-    "istanbul-reports": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.3.0.tgz",
-      "integrity": "sha512-y2Z2IMqE1gefWUaVjrBm0mSKvUkaBy9Vqz8iwr/r40Y9hBbIteH5wqHG/9DLTfJ9xUnUT2j7A3+VVJ6EaYBllA==",
-      "dev": true,
-      "requires": {
-        "handlebars": "4.0.11"
-      }
-    },
-    "istextorbinary": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.2.1.tgz",
-      "integrity": "sha512-TS+hoFl8Z5FAFMK38nhBkdLt44CclNRgDHWeMgsV8ko3nDlr/9UI2Sf839sW7enijf8oKsZYXRvM8g0it9Zmcw==",
-      "requires": {
-        "binaryextensions": "2.1.1",
-        "editions": "1.3.4",
-        "textextensions": "2.2.0"
-      }
-    },
-    "isurl": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
-      "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
-      "requires": {
-        "has-to-string-tag-x": "1.4.1",
-        "is-object": "1.0.1"
-      }
-    },
-    "jest": {
-      "version": "21.2.1",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-21.2.1.tgz",
-      "integrity": "sha512-mXN0ppPvWYoIcC+R+ctKxAJ28xkt/Z5Js875padm4GbgUn6baeR5N4Ng6LjatIRpUQDZVJABT7Y4gucFjPryfw==",
-      "dev": true,
-      "requires": {
-        "jest-cli": "21.2.1"
-      }
-    },
-    "jest-changed-files": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-21.2.0.tgz",
-      "integrity": "sha512-+lCNP1IZLwN1NOIvBcV5zEL6GENK6TXrDj4UxWIeLvIsIDa+gf6J7hkqsW2qVVt/wvH65rVvcPwqXdps5eclTQ==",
-      "dev": true,
-      "requires": {
-        "throat": "4.1.0"
-      }
-    },
-    "jest-cli": {
-      "version": "21.2.1",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-21.2.1.tgz",
-      "integrity": "sha512-T1BzrbFxDIW/LLYQqVfo94y/hhaj1NzVQkZgBumAC+sxbjMROI7VkihOdxNR758iYbQykL2ZOWUBurFgkQrzdg==",
-      "dev": true,
-      "requires": {
-        "ansi-escapes": "3.1.0",
-        "chalk": "2.4.0",
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "is-ci": "1.1.0",
-        "istanbul-api": "1.3.1",
-        "istanbul-lib-coverage": "1.2.0",
-        "istanbul-lib-instrument": "1.10.1",
-        "istanbul-lib-source-maps": "1.2.3",
-        "jest-changed-files": "21.2.0",
-        "jest-config": "21.2.1",
-        "jest-environment-jsdom": "21.2.1",
-        "jest-haste-map": "21.2.0",
-        "jest-message-util": "21.2.1",
-        "jest-regex-util": "21.2.0",
-        "jest-resolve-dependencies": "21.2.0",
-        "jest-runner": "21.2.1",
-        "jest-runtime": "21.2.1",
-        "jest-snapshot": "21.2.1",
-        "jest-util": "21.2.1",
-        "micromatch": "2.3.11",
-        "node-notifier": "5.2.1",
-        "pify": "3.0.0",
-        "slash": "1.0.0",
-        "string-length": "2.0.0",
-        "strip-ansi": "4.0.0",
-        "which": "1.3.0",
-        "worker-farm": "1.6.0",
-        "yargs": "9.0.1"
-      }
-    },
-    "jest-config": {
-      "version": "21.2.1",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-21.2.1.tgz",
-      "integrity": "sha512-fJru5HtlD/5l2o25eY9xT0doK3t2dlglrqoGpbktduyoI0T5CwuB++2YfoNZCrgZipTwPuAGonYv0q7+8yDc/A==",
-      "dev": true,
-      "requires": {
-        "chalk": "2.4.0",
-        "glob": "7.1.2",
-        "jest-environment-jsdom": "21.2.1",
-        "jest-environment-node": "21.2.1",
-        "jest-get-type": "21.2.0",
-        "jest-jasmine2": "21.2.1",
-        "jest-regex-util": "21.2.0",
-        "jest-resolve": "21.2.0",
-        "jest-util": "21.2.1",
-        "jest-validate": "21.2.1",
-        "pretty-format": "21.2.1"
-      }
-    },
-    "jest-diff": {
-      "version": "21.2.1",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-21.2.1.tgz",
-      "integrity": "sha512-E5fu6r7PvvPr5qAWE1RaUwIh/k6Zx/3OOkZ4rk5dBJkEWRrUuSgbMt2EO8IUTPTd6DOqU3LW6uTIwX5FRvXoFA==",
-      "dev": true,
-      "requires": {
-        "chalk": "2.4.0",
-        "diff": "3.5.0",
-        "jest-get-type": "21.2.0",
-        "pretty-format": "21.2.1"
-      }
-    },
-    "jest-docblock": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
-      "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
-      "dev": true
-    },
-    "jest-environment-jsdom": {
-      "version": "21.2.1",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-21.2.1.tgz",
-      "integrity": "sha512-mecaeNh0eWmzNrUNMWARysc0E9R96UPBamNiOCYL28k7mksb1d0q6DD38WKP7ABffjnXyUWJPVaWRgUOivwXwg==",
-      "dev": true,
-      "requires": {
-        "jest-mock": "21.2.0",
-        "jest-util": "21.2.1",
-        "jsdom": "9.12.0"
-      }
-    },
-    "jest-environment-node": {
-      "version": "21.2.1",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-21.2.1.tgz",
-      "integrity": "sha512-R211867wx9mVBVHzrjGRGTy5cd05K7eqzQl/WyZixR/VkJ4FayS8qkKXZyYnwZi6Rxo6WEV81cDbiUx/GfuLNw==",
-      "dev": true,
-      "requires": {
-        "jest-mock": "21.2.0",
-        "jest-util": "21.2.1"
-      }
-    },
-    "jest-get-type": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz",
-      "integrity": "sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q==",
-      "dev": true
-    },
-    "jest-haste-map": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-21.2.0.tgz",
-      "integrity": "sha512-5LhsY/loPH7wwOFRMs+PT4aIAORJ2qwgbpMFlbWbxfN0bk3ZCwxJ530vrbSiTstMkYLao6JwBkLhCJ5XbY7ZHw==",
-      "dev": true,
-      "requires": {
-        "fb-watchman": "2.0.0",
-        "graceful-fs": "4.1.11",
-        "jest-docblock": "21.2.0",
-        "micromatch": "2.3.11",
-        "sane": "2.5.0",
-        "worker-farm": "1.6.0"
-      }
-    },
-    "jest-jasmine2": {
-      "version": "21.2.1",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-21.2.1.tgz",
-      "integrity": "sha512-lw8FXXIEekD+jYNlStfgNsUHpfMWhWWCgHV7n0B7mA/vendH7vBFs8xybjQsDzJSduptBZJHqQX9SMssya9+3A==",
-      "dev": true,
-      "requires": {
-        "chalk": "2.4.0",
-        "expect": "21.2.1",
-        "graceful-fs": "4.1.11",
-        "jest-diff": "21.2.1",
-        "jest-matcher-utils": "21.2.1",
-        "jest-message-util": "21.2.1",
-        "jest-snapshot": "21.2.1",
-        "p-cancelable": "0.3.0"
-      }
-    },
-    "jest-matcher-utils": {
-      "version": "21.2.1",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-21.2.1.tgz",
-      "integrity": "sha512-kn56My+sekD43dwQPrXBl9Zn9tAqwoy25xxe7/iY4u+mG8P3ALj5IK7MLHZ4Mi3xW7uWVCjGY8cm4PqgbsqMCg==",
-      "dev": true,
-      "requires": {
-        "chalk": "2.4.0",
-        "jest-get-type": "21.2.0",
-        "pretty-format": "21.2.1"
-      }
-    },
-    "jest-message-util": {
-      "version": "21.2.1",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-21.2.1.tgz",
-      "integrity": "sha512-EbC1X2n0t9IdeMECJn2BOg7buOGivCvVNjqKMXTzQOu7uIfLml+keUfCALDh8o4rbtndIeyGU8/BKfoTr/LVDQ==",
-      "dev": true,
-      "requires": {
-        "chalk": "2.4.0",
-        "micromatch": "2.3.11",
-        "slash": "1.0.0"
-      }
-    },
-    "jest-mock": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-21.2.0.tgz",
-      "integrity": "sha512-aZDfyVf0LEoABWiY6N0d+O963dUQSyUa4qgzurHR3TBDPen0YxKCJ6l2i7lQGh1tVdsuvdrCZ4qPj+A7PievCw==",
-      "dev": true
-    },
-    "jest-regex-util": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-21.2.0.tgz",
-      "integrity": "sha512-BKQ1F83EQy0d9Jen/mcVX7D+lUt2tthhK/2gDWRgLDJRNOdRgSp1iVqFxP8EN1ARuypvDflRfPzYT8fQnoBQFQ==",
-      "dev": true
-    },
-    "jest-resolve": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-21.2.0.tgz",
-      "integrity": "sha512-vefQ/Lr+VdNvHUZFQXWtOqHX3HEdOc2MtSahBO89qXywEbUxGPB9ZLP9+BHinkxb60UT2Q/tTDOS6rYc6Mwigw==",
-      "dev": true,
-      "requires": {
-        "browser-resolve": "1.11.2",
-        "chalk": "2.4.0",
-        "is-builtin-module": "1.0.0"
-      }
-    },
-    "jest-resolve-dependencies": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-21.2.0.tgz",
-      "integrity": "sha512-ok8ybRFU5ScaAcfufIQrCbdNJSRZ85mkxJ1EhUp8Bhav1W1/jv/rl1Q6QoVQHObNxmKnbHVKrfLZbCbOsXQ+bQ==",
-      "dev": true,
-      "requires": {
-        "jest-regex-util": "21.2.0"
-      }
-    },
-    "jest-runner": {
-      "version": "21.2.1",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-21.2.1.tgz",
-      "integrity": "sha512-Anb72BOQlHqF/zETqZ2K20dbYsnqW/nZO7jV8BYENl+3c44JhMrA8zd1lt52+N7ErnsQMd2HHKiVwN9GYSXmrg==",
-      "dev": true,
-      "requires": {
-        "jest-config": "21.2.1",
-        "jest-docblock": "21.2.0",
-        "jest-haste-map": "21.2.0",
-        "jest-jasmine2": "21.2.1",
-        "jest-message-util": "21.2.1",
-        "jest-runtime": "21.2.1",
-        "jest-util": "21.2.1",
-        "pify": "3.0.0",
-        "throat": "4.1.0",
-        "worker-farm": "1.6.0"
-      }
-    },
-    "jest-runtime": {
-      "version": "21.2.1",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-21.2.1.tgz",
-      "integrity": "sha512-6omlpA3+NSE+rHwD0PQjNEjZeb2z+oRmuehMfM1tWQVum+E0WV3pFt26Am0DUfQkkPyTABvxITRjCUclYgSOsA==",
-      "dev": true,
-      "requires": {
-        "babel-core": "6.26.0",
-        "babel-jest": "21.2.0",
-        "babel-plugin-istanbul": "4.1.6",
-        "chalk": "2.4.0",
-        "convert-source-map": "1.5.1",
-        "graceful-fs": "4.1.11",
-        "jest-config": "21.2.1",
-        "jest-haste-map": "21.2.0",
-        "jest-regex-util": "21.2.0",
-        "jest-resolve": "21.2.0",
-        "jest-util": "21.2.1",
-        "json-stable-stringify": "1.0.1",
-        "micromatch": "2.3.11",
-        "slash": "1.0.0",
-        "strip-bom": "3.0.0",
-        "write-file-atomic": "2.3.0",
-        "yargs": "9.0.1"
-      }
-    },
-    "jest-snapshot": {
-      "version": "21.2.1",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-21.2.1.tgz",
-      "integrity": "sha512-bpaeBnDpdqaRTzN8tWg0DqOTo2DvD3StOemxn67CUd1p1Po+BUpvePAp44jdJ7Pxcjfg+42o4NHw1SxdCA2rvg==",
-      "dev": true,
-      "requires": {
-        "chalk": "2.4.0",
-        "jest-diff": "21.2.1",
-        "jest-matcher-utils": "21.2.1",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "pretty-format": "21.2.1"
-      }
-    },
-    "jest-util": {
-      "version": "21.2.1",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-21.2.1.tgz",
-      "integrity": "sha512-r20W91rmHY3fnCoO7aOAlyfC51x2yeV3xF+prGsJAUsYhKeV670ZB8NO88Lwm7ASu8SdH0S+U+eFf498kjhA4g==",
-      "dev": true,
-      "requires": {
-        "callsites": "2.0.0",
-        "chalk": "2.4.0",
-        "graceful-fs": "4.1.11",
-        "jest-message-util": "21.2.1",
-        "jest-mock": "21.2.0",
-        "jest-validate": "21.2.1",
-        "mkdirp": "0.5.1"
-      },
-      "dependencies": {
-        "callsites": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-          "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
-          "dev": true
-        }
-      }
-    },
-    "jest-validate": {
-      "version": "21.2.1",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-21.2.1.tgz",
-      "integrity": "sha512-k4HLI1rZQjlU+EC682RlQ6oZvLrE5SCh3brseQc24vbZTxzT/k/3urar5QMCVgjadmSO7lECeGdc6YxnM3yEGg==",
-      "dev": true,
-      "requires": {
-        "chalk": "2.4.0",
-        "jest-get-type": "21.2.0",
-        "leven": "2.1.0",
-        "pretty-format": "21.2.1"
-      }
-    },
-    "js-tokens": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-      "dev": true
-    },
-    "js-yaml": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
-      "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
-      "dev": true,
-      "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.0"
-      }
-    },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true,
-      "optional": true
-    },
-    "jsdom": {
-      "version": "9.12.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.12.0.tgz",
-      "integrity": "sha1-6MVG//ywbADUgzyoRBD+1/igl9Q=",
-      "dev": true,
-      "requires": {
-        "abab": "1.0.4",
-        "acorn": "4.0.13",
-        "acorn-globals": "3.1.0",
-        "array-equal": "1.0.0",
-        "content-type-parser": "1.0.2",
-        "cssom": "0.3.2",
-        "cssstyle": "0.2.37",
-        "escodegen": "1.9.1",
-        "html-encoding-sniffer": "1.0.2",
-        "nwmatcher": "1.4.4",
-        "parse5": "1.5.1",
-        "request": "2.79.0",
-        "sax": "1.2.4",
-        "symbol-tree": "3.2.2",
-        "tough-cookie": "2.3.4",
-        "webidl-conversions": "4.0.2",
-        "whatwg-encoding": "1.0.3",
-        "whatwg-url": "4.8.0",
-        "xml-name-validator": "2.0.1"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "4.0.13",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
-          "dev": true
-        }
-      }
-    },
-    "jsesc": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
-      "dev": true
-    },
-    "json-buffer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
-      "dev": true
-    },
-    "json-parse-better-errors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
-    },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-      "dev": true
-    },
-    "json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-      "dev": true
-    },
-    "json-stable-stringify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true,
-      "requires": {
-        "jsonify": "0.0.0"
-      }
-    },
-    "json-stable-stringify-without-jsonify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
-      "dev": true
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
-    },
-    "json5": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-      "dev": true
-    },
-    "jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11"
-      }
-    },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true
-    },
-    "jsonparse": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
-      "dev": true
-    },
-    "jsonpointer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
-      "dev": true
-    },
-    "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
-      }
-    },
-    "keyv": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
-      "integrity": "sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==",
-      "dev": true,
-      "requires": {
-        "json-buffer": "3.0.0"
-      }
-    },
-    "kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
-      "requires": {
-        "is-buffer": "1.1.6"
-      }
-    },
-    "lazy-cache": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-      "dev": true,
-      "optional": true
-    },
-    "lcid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "dev": true,
-      "requires": {
-        "invert-kv": "1.0.0"
-      }
-    },
-    "lcov-parse": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
-      "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
-      "dev": true
-    },
-    "leven": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
-      "dev": true
-    },
-    "levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
-      }
-    },
-    "lint-staged": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-4.3.0.tgz",
-      "integrity": "sha512-C/Zxslg0VRbsxwmCu977iIs+QyrmW2cyRCPUV5NDFYOH/jtRFHH8ch7ua2fH0voI/nVC3Tpg7DykfgMZySliKw==",
-      "dev": true,
-      "requires": {
-        "app-root-path": "2.0.1",
-        "chalk": "2.4.0",
-        "commander": "2.15.1",
-        "cosmiconfig": "1.1.0",
-        "execa": "0.8.0",
-        "is-glob": "4.0.0",
-        "jest-validate": "21.2.1",
-        "listr": "0.12.0",
-        "lodash": "4.17.5",
-        "log-symbols": "2.2.0",
-        "minimatch": "3.0.4",
-        "npm-which": "3.0.1",
-        "p-map": "1.2.0",
-        "staged-git-files": "0.0.4",
-        "stringify-object": "3.2.2"
-      },
-      "dependencies": {
-        "execa": {
-          "version": "0.8.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
-          "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "5.1.0",
-            "get-stream": "3.0.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
-          }
+        "cardinal": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/cardinal/-/cardinal-1.0.0.tgz",
+            "integrity": "sha1-UOIcGwqjdyn5N33vGWtanOyTLuk=",
+            "dev": true,
+            "requires": {
+                "ansicolors": "0.2.1",
+                "redeyed": "1.0.1"
+            }
         },
-        "is-extglob": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-          "dev": true
+        "caseless": {
+            "version": "0.12.0",
+            "resolved":
+                "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+            "dev": true
         },
-        "is-glob": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
-          "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "2.1.1"
-          }
-        }
-      }
-    },
-    "listr": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/listr/-/listr-0.12.0.tgz",
-      "integrity": "sha1-a84sD1YD+klYDqF81qAMwOX6RRo=",
-      "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "cli-truncate": "0.2.1",
-        "figures": "1.7.0",
-        "indent-string": "2.1.0",
-        "is-promise": "2.1.0",
-        "is-stream": "1.1.0",
-        "listr-silent-renderer": "1.1.1",
-        "listr-update-renderer": "0.2.0",
-        "listr-verbose-renderer": "0.4.1",
-        "log-symbols": "1.0.2",
-        "log-update": "1.0.2",
-        "ora": "0.2.3",
-        "p-map": "1.2.0",
-        "rxjs": "5.5.10",
-        "stream-to-observable": "0.1.0",
-        "strip-ansi": "3.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
+        "center-align": {
+            "version": "0.1.3",
+            "resolved":
+                "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+            "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "align-text": "0.1.4",
+                "lazy-cache": "1.0.4"
+            }
         },
         "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+            "integrity":
+                "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+            "requires": {
+                "ansi-styles": "3.2.1",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "5.4.0"
+            }
         },
-        "figures": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-          "dev": true,
-          "requires": {
-            "escape-string-regexp": "1.0.5",
-            "object-assign": "4.1.1"
-          }
+        "chardet": {
+            "version": "0.4.2",
+            "resolved":
+                "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+            "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
         },
-        "log-symbols": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
-          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-          "dev": true,
-          "requires": {
-            "chalk": "1.1.3"
-          }
+        "ci-info": {
+            "version": "1.1.3",
+            "resolved":
+                "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
+            "integrity":
+                "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
+            "dev": true
         },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
+        "circular-json": {
+            "version": "0.3.3",
+            "resolved":
+                "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+            "integrity":
+                "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+            "dev": true
         },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
-      }
-    },
-    "listr-silent-renderer": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
-      "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
-      "dev": true
-    },
-    "listr-update-renderer": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.2.0.tgz",
-      "integrity": "sha1-yoDhd5tOcCZoB+ju0a1qvjmFUPk=",
-      "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "cli-truncate": "0.2.1",
-        "elegant-spinner": "1.0.1",
-        "figures": "1.7.0",
-        "indent-string": "3.2.0",
-        "log-symbols": "1.0.2",
-        "log-update": "1.0.2",
-        "strip-ansi": "3.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+        "class-utils": {
+            "version": "0.3.6",
+            "resolved":
+                "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+            "integrity":
+                "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+            "requires": {
+                "arr-union": "3.1.0",
+                "define-property": "0.2.5",
+                "isobject": "3.0.1",
+                "static-extend": "0.1.2"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved":
+                        "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "requires": {
+                        "is-descriptor": "0.1.6"
+                    }
+                }
+            }
         },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
+        "clean-stack": {
+            "version": "1.3.0",
+            "resolved":
+                "https://registry.npmjs.org/clean-stack/-/clean-stack-1.3.0.tgz",
+            "integrity": "sha1-noIVAa6XmYbEax1m0tQy2y/UrjE=",
+            "dev": true
         },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "figures": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-          "dev": true,
-          "requires": {
-            "escape-string-regexp": "1.0.5",
-            "object-assign": "4.1.1"
-          }
-        },
-        "indent-string": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-          "dev": true
-        },
-        "log-symbols": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
-          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-          "dev": true,
-          "requires": {
-            "chalk": "1.1.3"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
-      }
-    },
-    "listr-verbose-renderer": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
-      "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
-      "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "date-fns": "1.29.0",
-        "figures": "1.7.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
+        "cli-boxes": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+            "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
         },
         "cli-cursor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-          "dev": true,
-          "requires": {
-            "restore-cursor": "1.0.1"
-          }
-        },
-        "figures": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-          "dev": true,
-          "requires": {
-            "escape-string-regexp": "1.0.5",
-            "object-assign": "4.1.1"
-          }
-        },
-        "onetime": {
-          "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-          "dev": true
-        },
-        "restore-cursor": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-          "dev": true,
-          "requires": {
-            "exit-hook": "1.1.1",
-            "onetime": "1.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
-      }
-    },
-    "load-json-file": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "4.0.0",
-        "pify": "3.0.0",
-        "strip-bom": "3.0.0"
-      }
-    },
-    "locate-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-      "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
-      }
-    },
-    "lodash": {
-      "version": "4.17.5",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
-    },
-    "lodash._baseassign": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true,
-      "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
-      }
-    },
-    "lodash._basecopy": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
-      "dev": true
-    },
-    "lodash._bindcallback": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
-      "dev": true
-    },
-    "lodash._createassigner": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
-      "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
-      "dev": true,
-      "requires": {
-        "lodash._bindcallback": "3.0.1",
-        "lodash._isiterateecall": "3.0.9",
-        "lodash.restparam": "3.6.1"
-      }
-    },
-    "lodash._getnative": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-      "dev": true
-    },
-    "lodash._isiterateecall": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
-      "dev": true
-    },
-    "lodash._reinterpolate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
-      "dev": true
-    },
-    "lodash.assign": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
-      "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
-      "dev": true,
-      "requires": {
-        "lodash._baseassign": "3.2.0",
-        "lodash._createassigner": "3.1.1",
-        "lodash.keys": "3.1.2"
-      }
-    },
-    "lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-      "dev": true
-    },
-    "lodash.isarray": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-      "dev": true
-    },
-    "lodash.keys": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true,
-      "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
-      }
-    },
-    "lodash.restparam": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
-      "dev": true
-    },
-    "lodash.template": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
-      "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
-      "dev": true,
-      "requires": {
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.templatesettings": "4.1.0"
-      }
-    },
-    "lodash.templatesettings": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
-      "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
-      "dev": true,
-      "requires": {
-        "lodash._reinterpolate": "3.0.0"
-      }
-    },
-    "log-driver": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
-      "integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY=",
-      "dev": true
-    },
-    "log-symbols": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
-      "requires": {
-        "chalk": "2.4.0"
-      }
-    },
-    "log-update": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
-      "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
-      "dev": true,
-      "requires": {
-        "ansi-escapes": "1.4.0",
-        "cli-cursor": "1.0.2"
-      },
-      "dependencies": {
-        "ansi-escapes": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
-          "dev": true
-        },
-        "cli-cursor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-          "dev": true,
-          "requires": {
-            "restore-cursor": "1.0.1"
-          }
-        },
-        "onetime": {
-          "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-          "dev": true
-        },
-        "restore-cursor": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-          "dev": true,
-          "requires": {
-            "exit-hook": "1.1.1",
-            "onetime": "1.1.0"
-          }
-        }
-      }
-    },
-    "lolex": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
-      "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
-      "dev": true
-    },
-    "longest": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
-    },
-    "loose-envify": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-      "dev": true,
-      "requires": {
-        "js-tokens": "3.0.2"
-      }
-    },
-    "loud-rejection": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-      "dev": true,
-      "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
-      }
-    },
-    "lowercase-keys": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
-    },
-    "lru-cache": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
-      "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
-      "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
-      }
-    },
-    "make-dir": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
-      "integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
-      "requires": {
-        "pify": "3.0.0"
-      }
-    },
-    "makeerror": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
-      "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
-      "dev": true,
-      "requires": {
-        "tmpl": "1.0.4"
-      }
-    },
-    "map-cache": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-      "dev": true
-    },
-    "map-obj": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-      "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
-      "dev": true
-    },
-    "map-visit": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
-      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
-      "dev": true,
-      "requires": {
-        "object-visit": "1.0.1"
-      }
-    },
-    "mem": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-      "dev": true,
-      "requires": {
-        "mimic-fn": "1.2.0"
-      }
-    },
-    "mem-fs": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/mem-fs/-/mem-fs-1.1.3.tgz",
-      "integrity": "sha1-uK6NLj/Lb10/kWXBLUVRoGXZicw=",
-      "requires": {
-        "through2": "2.0.3",
-        "vinyl": "1.2.0",
-        "vinyl-file": "2.0.0"
-      },
-      "dependencies": {
-        "clone": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
-        },
-        "clone-stats": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-          "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
-        },
-        "replace-ext": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-          "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
-        },
-        "vinyl": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-          "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-          "requires": {
-            "clone": "1.0.4",
-            "clone-stats": "0.0.1",
-            "replace-ext": "0.0.1"
-          }
-        }
-      }
-    },
-    "mem-fs-editor": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-3.0.2.tgz",
-      "integrity": "sha1-3Qpuryu4prN3QAZ6pUnrUwEFr58=",
-      "requires": {
-        "commondir": "1.0.1",
-        "deep-extend": "0.4.2",
-        "ejs": "2.5.9",
-        "glob": "7.1.2",
-        "globby": "6.1.0",
-        "mkdirp": "0.5.1",
-        "multimatch": "2.1.0",
-        "rimraf": "2.6.2",
-        "through2": "2.0.3",
-        "vinyl": "2.1.0"
-      }
-    },
-    "meow": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.0.tgz",
-      "integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
-      "dev": true,
-      "requires": {
-        "camelcase-keys": "4.2.0",
-        "decamelize-keys": "1.1.0",
-        "loud-rejection": "1.6.0",
-        "minimist": "1.2.0",
-        "minimist-options": "3.0.2",
-        "normalize-package-data": "2.4.0",
-        "read-pkg-up": "3.0.0",
-        "redent": "2.0.0",
-        "trim-newlines": "2.0.0"
-      }
-    },
-    "merge": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
-      "dev": true
-    },
-    "micromatch": {
-      "version": "2.3.11",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-      "dev": true,
-      "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.4"
-      },
-      "dependencies": {
-        "normalize-path": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-          "dev": true,
-          "requires": {
-            "remove-trailing-separator": "1.1.0"
-          }
-        }
-      }
-    },
-    "mime": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
-      "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg==",
-      "dev": true
-    },
-    "mime-db": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
-      "dev": true
-    },
-    "mime-types": {
-      "version": "2.1.18",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
-      "dev": true,
-      "requires": {
-        "mime-db": "1.33.0"
-      }
-    },
-    "mimic-fn": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
-    },
-    "mimic-response": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.0.tgz",
-      "integrity": "sha1-3z02Uqc/3ta5sLJBRub9BSNTRY4="
-    },
-    "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "requires": {
-        "brace-expansion": "1.1.11"
-      }
-    },
-    "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-    },
-    "minimist-options": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
-      "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
-      "dev": true,
-      "requires": {
-        "arrify": "1.0.1",
-        "is-plain-obj": "1.1.0"
-      }
-    },
-    "minipass": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
-      "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1",
-        "yallist": "3.0.2"
-      },
-      "dependencies": {
-        "yallist": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true
-        }
-      }
-    },
-    "minizlib": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
-      "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "minipass": "2.2.4"
-      }
-    },
-    "mixin-deep": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
-      "dev": true,
-      "requires": {
-        "for-in": "1.0.2",
-        "is-extendable": "1.0.1"
-      },
-      "dependencies": {
-        "is-extendable": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-          "dev": true,
-          "requires": {
-            "is-plain-object": "2.0.4"
-          }
-        }
-      }
-    },
-    "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "requires": {
-        "minimist": "0.0.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-        }
-      }
-    },
-    "modify-values": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
-      "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
-      "dev": true
-    },
-    "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-    },
-    "multimatch": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
-      "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
-      "requires": {
-        "array-differ": "1.0.0",
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "minimatch": "3.0.4"
-      }
-    },
-    "mute-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
-    },
-    "nan": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
-      "dev": true,
-      "optional": true
-    },
-    "nanomatch": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
-      "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
-      "dev": true,
-      "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "fragment-cache": "0.2.1",
-        "is-odd": "2.0.0",
-        "is-windows": "1.0.2",
-        "kind-of": "6.0.2",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
-      },
-      "dependencies": {
-        "arr-diff": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-          "dev": true
-        },
-        "array-unique": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-          "dev": true
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
-        }
-      }
-    },
-    "native-promise-only": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
-      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
-      "dev": true
-    },
-    "natural-compare": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-      "dev": true
-    },
-    "needle": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.0.tgz",
-      "integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "debug": "2.6.9",
-        "iconv-lite": "0.4.21",
-        "sax": "1.2.4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "nerf-dart": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
-      "integrity": "sha1-5tq3/r9a2Bbqgc9cYpxaDr3nLBo=",
-      "dev": true
-    },
-    "netrc": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/netrc/-/netrc-0.1.4.tgz",
-      "integrity": "sha1-a+lPysqNd63gqWcNxGCRTJRHJEQ=",
-      "dev": true
-    },
-    "node-int64": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
-      "dev": true
-    },
-    "node-notifier": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
-      "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
-      "dev": true,
-      "requires": {
-        "growly": "1.3.0",
-        "semver": "5.5.0",
-        "shellwords": "0.1.1",
-        "which": "1.3.0"
-      }
-    },
-    "nopt": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-      "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-      "dev": true,
-      "requires": {
-        "abbrev": "1.1.1",
-        "osenv": "0.1.5"
-      }
-    },
-    "normalize-package-data": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-      "requires": {
-        "hosted-git-info": "2.6.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.5.0",
-        "validate-npm-package-license": "3.0.3"
-      }
-    },
-    "normalize-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
-      "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
-      "dev": true
-    },
-    "normalize-url": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
-      "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
-      "dev": true,
-      "requires": {
-        "prepend-http": "2.0.0",
-        "query-string": "5.1.1",
-        "sort-keys": "2.0.0"
-      },
-      "dependencies": {
-        "prepend-http": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-          "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
-          "dev": true
-        }
-      }
-    },
-    "npm-bundled": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
-      "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
-      "dev": true,
-      "optional": true
-    },
-    "npm-package-arg": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.0.tgz",
-      "integrity": "sha512-zYbhP2k9DbJhA0Z3HKUePUgdB1x7MfIfKssC+WLPFMKTBZKpZh5m13PgexJjCq6KW7j17r0jHWcCpxEqnnncSA==",
-      "dev": true,
-      "requires": {
-        "hosted-git-info": "2.6.0",
-        "osenv": "0.1.5",
-        "semver": "5.5.0",
-        "validate-npm-package-name": "3.0.0"
-      }
-    },
-    "npm-packlist": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
-      "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "ignore-walk": "3.0.1",
-        "npm-bundled": "1.0.3"
-      }
-    },
-    "npm-path": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.4.tgz",
-      "integrity": "sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==",
-      "dev": true,
-      "requires": {
-        "which": "1.3.0"
-      }
-    },
-    "npm-registry-client": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-8.5.1.tgz",
-      "integrity": "sha512-7rjGF2eA7hKDidGyEWmHTiKfXkbrcQAsGL/Rh4Rt3x3YNRNHhwaTzVJfW3aNvvlhg4G62VCluif0sLCb/i51Hg==",
-      "dev": true,
-      "requires": {
-        "concat-stream": "1.6.2",
-        "graceful-fs": "4.1.11",
-        "normalize-package-data": "2.4.0",
-        "npm-package-arg": "6.1.0",
-        "npmlog": "4.1.2",
-        "once": "1.4.0",
-        "request": "2.79.0",
-        "retry": "0.10.1",
-        "safe-buffer": "5.1.1",
-        "semver": "5.5.0",
-        "slide": "1.1.6",
-        "ssri": "5.3.0"
-      }
-    },
-    "npm-run-path": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "dev": true,
-      "requires": {
-        "path-key": "2.0.1"
-      }
-    },
-    "npm-which": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/npm-which/-/npm-which-3.0.1.tgz",
-      "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
-      "dev": true,
-      "requires": {
-        "commander": "2.15.1",
-        "npm-path": "2.0.4",
-        "which": "1.3.0"
-      }
-    },
-    "npmconf": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.2.tgz",
-      "integrity": "sha1-ZmBqSnNvHnegWaoHGnnJSreBhTo=",
-      "dev": true,
-      "requires": {
-        "config-chain": "1.1.11",
-        "inherits": "2.0.3",
-        "ini": "1.3.5",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "once": "1.3.3",
-        "osenv": "0.1.5",
-        "semver": "4.3.6",
-        "uid-number": "0.0.5"
-      },
-      "dependencies": {
-        "nopt": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-          "dev": true,
-          "requires": {
-            "abbrev": "1.1.1"
-          }
-        },
-        "once": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-          "dev": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "semver": {
-          "version": "4.3.6",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-          "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
-          "dev": true
-        }
-      }
-    },
-    "npmlog": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-      "dev": true,
-      "requires": {
-        "are-we-there-yet": "1.1.4",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
-      }
-    },
-    "nsp": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/nsp/-/nsp-2.8.1.tgz",
-      "integrity": "sha512-jvjDg2Gsw4coD/iZ5eQddsDlkvnwMCNnpG05BproSnuG+Gr1bSQMwWMcQeYje+qdDl3XznmhblMPLpZLecTORQ==",
-      "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "cli-table": "0.3.1",
-        "cvss": "1.0.2",
-        "https-proxy-agent": "1.0.0",
-        "joi": "6.10.1",
-        "nodesecurity-npm-utils": "5.0.0",
-        "path-is-absolute": "1.0.1",
-        "rc": "1.2.1",
-        "semver": "5.4.1",
-        "subcommand": "2.1.0",
-        "wreck": "6.3.0"
-      },
-      "dependencies": {
-        "agent-base": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
-          "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
-          "dev": true,
-          "requires": {
-            "extend": "3.0.1",
-            "semver": "5.0.3"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "5.0.3",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
-              "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
-              "dev": true
+            "version": "2.1.0",
+            "resolved":
+                "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+            "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+            "requires": {
+                "restore-cursor": "2.0.0"
             }
-          }
         },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "boom": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
+        "cli-spinners": {
+            "version": "0.1.2",
+            "resolved":
+                "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz",
+            "integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=",
+            "dev": true
         },
         "cli-table": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
-          "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
-          "dev": true,
-          "requires": {
-            "colors": "1.0.3"
-          }
-        },
-        "cliclopts": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/cliclopts/-/cliclopts-1.1.1.tgz",
-          "integrity": "sha1-aUMcfLWvcjd0sNORG0w3USQxkQ8=",
-          "dev": true
-        },
-        "colors": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
-          "dev": true
-        },
-        "cvss": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/cvss/-/cvss-1.0.2.tgz",
-          "integrity": "sha1-32fpK/EqeW9J6Sh5nI2zunS5/NY=",
-          "dev": true
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-extend": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
-          "dev": true
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
-        },
-        "extend": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-          "dev": true
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-          "dev": true
-        },
-        "https-proxy-agent": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
-          "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
-          "dev": true,
-          "requires": {
-            "agent-base": "2.1.1",
-            "debug": "2.6.9",
-            "extend": "3.0.1"
-          }
-        },
-        "ini": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
-          "dev": true
-        },
-        "isemail": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
-          "integrity": "sha1-vgPfjMPineTSxd9lASY/H6RZXpo=",
-          "dev": true
-        },
-        "joi": {
-          "version": "6.10.1",
-          "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
-          "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3",
-            "isemail": "1.2.0",
-            "moment": "2.18.1",
-            "topo": "1.1.0"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
-        "moment": {
-          "version": "2.18.1",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-          "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8=",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        },
-        "nodesecurity-npm-utils": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/nodesecurity-npm-utils/-/nodesecurity-npm-utils-5.0.0.tgz",
-          "integrity": "sha1-Baow3jDKjIRcQEjpT9eOXgi1Xtk=",
-          "dev": true
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-          "dev": true
-        },
-        "rc": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
-          "dev": true,
-          "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
-          }
-        },
-        "semver": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-          "dev": true
-        },
-        "subcommand": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/subcommand/-/subcommand-2.1.0.tgz",
-          "integrity": "sha1-XkzspaN3njNlsVEeBfhmh3MC92A=",
-          "dev": true,
-          "requires": {
-            "cliclopts": "1.1.1",
-            "debug": "2.6.9",
-            "minimist": "1.2.0",
-            "xtend": "4.0.1"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        },
-        "topo": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
-          "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "wreck": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/wreck/-/wreck-6.3.0.tgz",
-          "integrity": "sha1-oTaXafB7u2LWo3gzanhx/Hc8dAs=",
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1",
-            "hoek": "2.16.3"
-          }
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-          "dev": true
-        }
-      }
-    },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-    },
-    "nwmatcher": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
-      "integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ==",
-      "dev": true
-    },
-    "oauth-sign": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-      "dev": true
-    },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-    },
-    "object-copy": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
-      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
-      "dev": true,
-      "requires": {
-        "copy-descriptor": "0.1.1",
-        "define-property": "0.2.5",
-        "kind-of": "3.2.2"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true,
-          "requires": {
-            "is-descriptor": "0.1.6"
-          }
-        }
-      }
-    },
-    "object-visit": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
-      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
-      "dev": true,
-      "requires": {
-        "isobject": "3.0.1"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        }
-      }
-    },
-    "object.omit": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "dev": true,
-      "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
-      }
-    },
-    "object.pick": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
-      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
-      "dev": true,
-      "requires": {
-        "isobject": "3.0.1"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        }
-      }
-    },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "requires": {
-        "wrappy": "1.0.2"
-      }
-    },
-    "onetime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-      "requires": {
-        "mimic-fn": "1.2.0"
-      }
-    },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
-      "requires": {
-        "minimist": "0.0.10",
-        "wordwrap": "0.0.3"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-          "dev": true
-        },
-        "wordwrap": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-          "dev": true
-        }
-      }
-    },
-    "optionator": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true,
-      "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
-      }
-    },
-    "ora": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
-      "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
-      "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "cli-spinners": "0.1.2",
-        "object-assign": "4.1.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "cli-cursor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-          "dev": true,
-          "requires": {
-            "restore-cursor": "1.0.1"
-          }
-        },
-        "onetime": {
-          "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-          "dev": true
-        },
-        "restore-cursor": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-          "dev": true,
-          "requires": {
-            "exit-hook": "1.1.1",
-            "onetime": "1.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
-      }
-    },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "dev": true
-    },
-    "os-locale": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-      "dev": true,
-      "requires": {
-        "execa": "0.7.0",
-        "lcid": "1.0.0",
-        "mem": "1.1.0"
-      }
-    },
-    "os-shim": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
-      "integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc=",
-      "dev": true
-    },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
-    },
-    "osenv": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-      "dev": true,
-      "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
-      }
-    },
-    "p-cancelable": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
-      "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
-    },
-    "p-finally": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
-    },
-    "p-is-promise": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
-      "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
-      "dev": true
-    },
-    "p-limit": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
-      "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
-      "requires": {
-        "p-try": "1.0.0"
-      }
-    },
-    "p-locate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-      "requires": {
-        "p-limit": "1.2.0"
-      }
-    },
-    "p-map": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
-      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
-      "dev": true
-    },
-    "p-reduce": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
-      "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
-      "dev": true
-    },
-    "p-retry": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-1.0.0.tgz",
-      "integrity": "sha1-OSczKkt9cCabU1UVEX/FR9oaaWg=",
-      "dev": true,
-      "requires": {
-        "retry": "0.10.1"
-      }
-    },
-    "p-series": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-series/-/p-series-1.1.0.tgz",
-      "integrity": "sha512-356covArc9UCfj2twY/sxCJKGMzzO+pJJtucizsPC6aS1xKSTBc9PQrQhvFR3+7F+fa2KBKdJjdIcv6NEWDcIQ==",
-      "dev": true,
-      "requires": {
-        "@sindresorhus/is": "0.7.0",
-        "p-reduce": "1.0.0"
-      }
-    },
-    "p-timeout": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
-      "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
-      "requires": {
-        "p-finally": "1.0.0"
-      }
-    },
-    "p-try": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
-    },
-    "pad-component": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/pad-component/-/pad-component-0.0.1.tgz",
-      "integrity": "sha1-rR8izhvw/cDW3dkIrxfzUaQEuKw="
-    },
-    "parse-github-repo-url": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
-      "integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A=",
-      "dev": true
-    },
-    "parse-glob": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "dev": true,
-      "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
-      }
-    },
-    "parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-      "requires": {
-        "error-ex": "1.3.1",
-        "json-parse-better-errors": "1.0.2"
-      }
-    },
-    "parse5": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
-      "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=",
-      "dev": true
-    },
-    "pascalcase": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
-      "dev": true
-    },
-    "path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-    },
-    "path-is-inside": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-      "dev": true
-    },
-    "path-key": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-      "dev": true
-    },
-    "path-object": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/path-object/-/path-object-2.3.0.tgz",
-      "integrity": "sha1-A+RmU+XDdcYK8cq92UvGRIpdkRA=",
-      "dev": true,
-      "requires": {
-        "core-util-is": "1.0.2",
-        "lodash.assign": "3.2.0"
-      }
-    },
-    "path-parse": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
-    },
-    "path-to-regexp": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
-      "dev": true,
-      "requires": {
-        "isarray": "0.0.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        }
-      }
-    },
-    "path-type": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-      "requires": {
-        "pify": "3.0.0"
-      }
-    },
-    "pify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-    },
-    "pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-    },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "requires": {
-        "pinkie": "2.0.4"
-      }
-    },
-    "pluralize": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
-      "dev": true
-    },
-    "posix-character-classes": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
-      "dev": true
-    },
-    "prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "dev": true
-    },
-    "prepend-http": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
-    },
-    "preserve": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-      "dev": true
-    },
-    "prettier": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.11.1.tgz",
-      "integrity": "sha512-T/KD65Ot0PB97xTrG8afQ46x3oiVhnfGjGESSI9NWYcG92+OUPZKkwHqGWXH2t9jK1crnQjubECW0FuOth+hxw==",
-      "dev": true
-    },
-    "pretty-bytes": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
-      "integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk="
-    },
-    "pretty-format": {
-      "version": "21.2.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
-      "integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "3.0.0",
-        "ansi-styles": "3.2.1"
-      }
-    },
-    "private": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
-      "dev": true
-    },
-    "process-nextick-args": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
-    },
-    "progress": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
-      "dev": true
-    },
-    "proto-list": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
-      "dev": true
-    },
-    "prr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
-      "dev": true
-    },
-    "pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-    },
-    "punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-      "dev": true
-    },
-    "q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
-      "dev": true
-    },
-    "qs": {
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-      "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
-      "dev": true
-    },
-    "query-string": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
-      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
-      "dev": true,
-      "requires": {
-        "decode-uri-component": "0.2.0",
-        "object-assign": "4.1.1",
-        "strict-uri-encode": "1.1.0"
-      }
-    },
-    "quick-lru": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
-      "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
-      "dev": true
-    },
-    "randomatic": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
-      "dev": true,
-      "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
+            "version": "0.3.1",
+            "resolved":
+                "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+            "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
+            "requires": {
+                "colors": "1.0.3"
             }
-          }
         },
-        "kind-of": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "1.1.6"
-          }
-        }
-      }
-    },
-    "read-chunk": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-2.1.0.tgz",
-      "integrity": "sha1-agTAkoAF7Z1C4aasVgDhnLx/9lU=",
-      "requires": {
-        "pify": "3.0.0",
-        "safe-buffer": "5.1.1"
-      }
-    },
-    "read-pkg": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-      "requires": {
-        "load-json-file": "4.0.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "3.0.0"
-      }
-    },
-    "read-pkg-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-      "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-      "requires": {
-        "find-up": "2.1.0",
-        "read-pkg": "3.0.0"
-      }
-    },
-    "readable-stream": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-      "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.1.1",
-        "util-deprecate": "1.0.2"
-      }
-    },
-    "rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "requires": {
-        "resolve": "1.7.1"
-      }
-    },
-    "redent": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
-      "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
-      "dev": true,
-      "requires": {
-        "indent-string": "3.2.0",
-        "strip-indent": "2.0.0"
-      },
-      "dependencies": {
-        "indent-string": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-          "dev": true
-        }
-      }
-    },
-    "regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "dev": true
-    },
-    "regex-cache": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-      "dev": true,
-      "requires": {
-        "is-equal-shallow": "0.1.3"
-      }
-    },
-    "regex-not": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
-      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
-      "dev": true,
-      "requires": {
-        "extend-shallow": "3.0.2",
-        "safe-regex": "1.1.0"
-      }
-    },
-    "regexpp": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
-      "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
-      "dev": true
-    },
-    "remove-trailing-separator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
-    },
-    "repeat-element": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-      "dev": true
-    },
-    "repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
-    },
-    "repeating": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true,
-      "requires": {
-        "is-finite": "1.0.2"
-      }
-    },
-    "replace-ext": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-      "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
-    },
-    "request": {
-      "version": "2.79.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-      "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
-      "dev": true,
-      "requires": {
-        "aws-sign2": "0.6.0",
-        "aws4": "1.7.0",
-        "caseless": "0.11.0",
-        "combined-stream": "1.0.6",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.1.4",
-        "har-validator": "2.0.6",
-        "hawk": "3.1.3",
-        "http-signature": "1.1.1",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.18",
-        "oauth-sign": "0.8.2",
-        "qs": "6.3.2",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.4",
-        "tunnel-agent": "0.4.3",
-        "uuid": "3.2.1"
-      }
-    },
-    "require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
-    },
-    "require-from-string": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
-      "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
-      "dev": true
-    },
-    "require-main-filename": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-      "dev": true
-    },
-    "require-relative": {
-      "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
-      "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
-      "dev": true
-    },
-    "require-uncached": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true,
-      "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
-      }
-    },
-    "resolve": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
-      "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
-      "requires": {
-        "path-parse": "1.0.5"
-      }
-    },
-    "resolve-from": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
-      "dev": true
-    },
-    "resolve-url": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-      "dev": true
-    },
-    "responselike": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
-      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
-      "dev": true,
-      "requires": {
-        "lowercase-keys": "1.0.1"
-      }
-    },
-    "restore-cursor": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-      "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
-      }
-    },
-    "ret": {
-      "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-      "dev": true
-    },
-    "retry": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
-      "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
-      "dev": true
-    },
-    "right-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "align-text": "0.1.4"
-      }
-    },
-    "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-      "requires": {
-        "glob": "7.1.2"
-      }
-    },
-    "run-async": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-      "requires": {
-        "is-promise": "2.1.0"
-      }
-    },
-    "rx": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
-      "dev": true
-    },
-    "rx-lite": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
-    },
-    "rx-lite-aggregates": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
-      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-      "requires": {
-        "rx-lite": "4.0.8"
-      }
-    },
-    "rxjs": {
-      "version": "5.5.10",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.10.tgz",
-      "integrity": "sha512-SRjimIDUHJkon+2hFo7xnvNC4ZEHGzCRwh9P7nzX3zPkCGFEg/tuElrNR7L/rZMagnK2JeH2jQwPRpmyXyLB6A==",
-      "dev": true,
-      "requires": {
-        "symbol-observable": "1.0.1"
-      }
-    },
-    "safe-buffer": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
-    },
-    "safe-regex": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
-      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
-      "dev": true,
-      "requires": {
-        "ret": "0.1.15"
-      }
-    },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "samsam": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
-      "dev": true
-    },
-    "sane": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/sane/-/sane-2.5.0.tgz",
-      "integrity": "sha512-glfKd7YH4UCrh/7dD+UESsr8ylKWRE7UQPoXuz28FgmcF0ViJQhCTCCZHICRKxf8G8O1KdLEn20dcICK54c7ew==",
-      "dev": true,
-      "requires": {
-        "anymatch": "2.0.0",
-        "exec-sh": "0.2.1",
-        "fb-watchman": "2.0.0",
-        "fsevents": "1.2.0",
-        "micromatch": "3.1.10",
-        "minimist": "1.2.0",
-        "walker": "1.0.7",
-        "watch": "0.18.0"
-      },
-      "dependencies": {
-        "arr-diff": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-          "dev": true
-        },
-        "array-unique": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-          "dev": true
-        },
-        "braces": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "1.1.0",
-            "array-unique": "0.3.2",
-            "extend-shallow": "2.0.1",
-            "fill-range": "4.0.0",
-            "isobject": "3.0.1",
-            "repeat-element": "1.1.2",
-            "snapdragon": "0.8.2",
-            "snapdragon-node": "2.1.1",
-            "split-string": "3.1.0",
-            "to-regex": "3.0.2"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "0.1.1"
-              }
-            }
-          }
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "expand-brackets": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-          "dev": true,
-          "requires": {
-            "debug": "2.6.9",
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "posix-character-classes": "0.1.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "0.2.5",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-              "dev": true,
-              "requires": {
-                "is-descriptor": "0.1.6"
-              }
+        "cli-table2": {
+            "version": "0.2.0",
+            "resolved":
+                "https://registry.npmjs.org/cli-table2/-/cli-table2-0.2.0.tgz",
+            "integrity": "sha1-LR738hig54biFFQFYtS9F3/jLZc=",
+            "dev": true,
+            "requires": {
+                "colors": "1.2.5",
+                "lodash": "3.10.1",
+                "string-width": "1.0.2"
             },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "0.1.1"
-              }
-            },
-            "is-accessor-descriptor": {
-              "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-              "dev": true,
-              "requires": {
-                "kind-of": "3.2.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "1.1.6"
-                  }
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved":
+                        "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                },
+                "colors": {
+                    "version": "1.2.5",
+                    "resolved":
+                        "https://registry.npmjs.org/colors/-/colors-1.2.5.tgz",
+                    "integrity":
+                        "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==",
+                    "dev": true,
+                    "optional": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                    "dev": true,
+                    "requires": {
+                        "number-is-nan": "1.0.1"
+                    }
+                },
+                "lodash": {
+                    "version": "3.10.1",
+                    "resolved":
+                        "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                    "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "resolved":
+                        "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                    "dev": true,
+                    "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
                 }
-              }
+            }
+        },
+        "cli-truncate": {
+            "version": "0.2.1",
+            "resolved":
+                "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
+            "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+            "dev": true,
+            "requires": {
+                "slice-ansi": "0.0.4",
+                "string-width": "1.0.2"
             },
-            "is-data-descriptor": {
-              "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-              "dev": true,
-              "requires": {
-                "kind-of": "3.2.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "1.1.6"
-                  }
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved":
+                        "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                    "dev": true,
+                    "requires": {
+                        "number-is-nan": "1.0.1"
+                    }
+                },
+                "slice-ansi": {
+                    "version": "0.0.4",
+                    "resolved":
+                        "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+                    "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "resolved":
+                        "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                    "dev": true,
+                    "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
                 }
-              }
-            },
-            "is-descriptor": {
-              "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
-              }
-            },
-            "kind-of": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-              "dev": true
             }
-          }
         },
-        "extglob": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-          "dev": true,
-          "requires": {
-            "array-unique": "0.3.2",
-            "define-property": "1.0.0",
-            "expand-brackets": "2.1.4",
-            "extend-shallow": "2.0.1",
-            "fragment-cache": "0.2.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-              "dev": true,
-              "requires": {
-                "is-descriptor": "1.0.2"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "0.1.1"
-              }
-            }
-          }
-        },
-        "fill-range": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "2.0.1",
-            "is-number": "3.0.0",
-            "repeat-string": "1.6.1",
-            "to-regex-range": "2.1.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "0.1.1"
-              }
-            }
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-          "dev": true,
-          "requires": {
-            "kind-of": "6.0.2"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-          "dev": true,
-          "requires": {
-            "kind-of": "6.0.2"
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
-          }
-        },
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
-        },
-        "micromatch": {
-          "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-          "dev": true,
-          "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "braces": "2.3.2",
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "extglob": "2.0.4",
-            "fragment-cache": "0.2.1",
-            "kind-of": "6.0.2",
-            "nanomatch": "1.2.9",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
-          }
-        }
-      }
-    },
-    "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
-    },
-    "scoped-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/scoped-regex/-/scoped-regex-1.0.0.tgz",
-      "integrity": "sha1-o0a7Gs1CB65wvXwMfKnlZra63bg="
-    },
-    "semantic-release": {
-      "version": "8.2.3",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-8.2.3.tgz",
-      "integrity": "sha512-L0EKspX5xaPKhrrZWwbdlydwk+uXQG+SadYlaQjYQJjaBSfptd+jL6FRu3LspZoLxvKF8yQWe4sYAySHcp69aw==",
-      "dev": true,
-      "requires": {
-        "@semantic-release/commit-analyzer": "3.0.7",
-        "@semantic-release/condition-travis": "6.2.1",
-        "@semantic-release/error": "2.2.0",
-        "@semantic-release/last-release-npm": "2.0.2",
-        "@semantic-release/release-notes-generator": "4.0.5",
-        "execa": "0.8.0",
-        "fs-extra": "4.0.3",
-        "git-head": "1.20.1",
-        "github": "12.1.0",
-        "lodash": "4.17.5",
-        "nerf-dart": "1.0.0",
-        "nopt": "4.0.1",
-        "normalize-package-data": "2.4.0",
-        "npmconf": "2.1.2",
-        "npmlog": "4.1.2",
-        "p-series": "1.1.0",
-        "parse-github-repo-url": "1.4.1",
-        "require-relative": "0.8.7",
-        "semver": "5.5.0"
-      },
-      "dependencies": {
-        "execa": {
-          "version": "0.8.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
-          "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "5.1.0",
-            "get-stream": "3.0.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
-          }
-        }
-      }
-    },
-    "semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
-    },
-    "set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
-    },
-    "set-value": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
-      "dev": true,
-      "requires": {
-        "extend-shallow": "2.0.1",
-        "is-extendable": "0.1.1",
-        "is-plain-object": "2.0.4",
-        "split-string": "3.1.0"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "0.1.1"
-          }
-        }
-      }
-    },
-    "shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "requires": {
-        "shebang-regex": "1.0.0"
-      }
-    },
-    "shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
-    },
-    "shelljs": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.1.tgz",
-      "integrity": "sha512-YA/iYtZpzFe5HyWVGrb02FjPxc4EMCfpoU/Phg9fQoyMC72u9598OUBrsU8IrtwAKG0tO8IYaqbaLIw+k3IRGA==",
-      "requires": {
-        "glob": "7.1.2",
-        "interpret": "1.1.0",
-        "rechoir": "0.6.2"
-      }
-    },
-    "shellwords": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
-      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "dev": true
-    },
-    "signal-exit": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-    },
-    "sinon": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.4.1.tgz",
-      "integrity": "sha512-vFTrO9Wt0ECffDYIPSP/E5bBugt0UjcBQOfQUMh66xzkyPEnhl/vM2LRZi2ajuTdkH07sA6DzrM6KvdvGIH8xw==",
-      "dev": true,
-      "requires": {
-        "diff": "3.5.0",
-        "formatio": "1.2.0",
-        "lolex": "1.6.0",
-        "native-promise-only": "0.8.1",
-        "path-to-regexp": "1.7.0",
-        "samsam": "1.3.0",
-        "text-encoding": "0.6.4",
-        "type-detect": "4.0.8"
-      }
-    },
-    "slash": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-      "dev": true
-    },
-    "slice-ansi": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
-      "dev": true,
-      "requires": {
-        "is-fullwidth-code-point": "2.0.0"
-      }
-    },
-    "slide": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
-      "dev": true
-    },
-    "snapdragon": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
-      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
-      "dev": true,
-      "requires": {
-        "base": "0.11.2",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "map-cache": "0.2.2",
-        "source-map": "0.5.7",
-        "source-map-resolve": "0.5.1",
-        "use": "3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true,
-          "requires": {
-            "is-descriptor": "0.1.6"
-          }
-        },
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "0.1.1"
-          }
-        }
-      }
-    },
-    "snapdragon-node": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
-      "dev": true,
-      "requires": {
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "snapdragon-util": "3.0.1"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-          "dev": true,
-          "requires": {
-            "is-descriptor": "1.0.2"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-          "dev": true,
-          "requires": {
-            "kind-of": "6.0.2"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-          "dev": true,
-          "requires": {
-            "kind-of": "6.0.2"
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
-        }
-      }
-    },
-    "snapdragon-util": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
-      "dev": true,
-      "requires": {
-        "kind-of": "3.2.2"
-      }
-    },
-    "sntp": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "dev": true,
-      "requires": {
-        "hoek": "2.16.3"
-      }
-    },
-    "sort-keys": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
-      "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
-      "dev": true,
-      "requires": {
-        "is-plain-obj": "1.1.0"
-      }
-    },
-    "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
-    },
-    "source-map-resolve": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
-      "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
-      "dev": true,
-      "requires": {
-        "atob": "2.1.0",
-        "decode-uri-component": "0.2.0",
-        "resolve-url": "0.2.1",
-        "source-map-url": "0.4.0",
-        "urix": "0.1.0"
-      }
-    },
-    "source-map-support": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-      "dev": true,
-      "requires": {
-        "source-map": "0.5.7"
-      }
-    },
-    "source-map-url": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-      "dev": true
-    },
-    "spawn-sync": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
-      "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
-      "dev": true,
-      "requires": {
-        "concat-stream": "1.6.2",
-        "os-shim": "0.1.3"
-      }
-    },
-    "spdx-correct": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
-      "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
-      "requires": {
-        "spdx-expression-parse": "3.0.0",
-        "spdx-license-ids": "3.0.0"
-      }
-    },
-    "spdx-exceptions": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
-    },
-    "spdx-expression-parse": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
-      "requires": {
-        "spdx-exceptions": "2.1.0",
-        "spdx-license-ids": "3.0.0"
-      }
-    },
-    "spdx-license-ids": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
-    },
-    "split": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-      "dev": true,
-      "requires": {
-        "through": "2.3.8"
-      }
-    },
-    "split-string": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
-      "dev": true,
-      "requires": {
-        "extend-shallow": "3.0.2"
-      }
-    },
-    "split2": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
-      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
-      "dev": true,
-      "requires": {
-        "through2": "2.0.3"
-      }
-    },
-    "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
-    },
-    "sshpk": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
-      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
-      "dev": true,
-      "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
-      }
-    },
-    "ssri": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
-      "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
-    "staged-git-files": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/staged-git-files/-/staged-git-files-0.0.4.tgz",
-      "integrity": "sha1-15fhtVHKemOd7AI33G60u5vhfTU=",
-      "dev": true
-    },
-    "static-extend": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
-      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
-      "dev": true,
-      "requires": {
-        "define-property": "0.2.5",
-        "object-copy": "0.1.0"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true,
-          "requires": {
-            "is-descriptor": "0.1.6"
-          }
-        }
-      }
-    },
-    "stream-to-observable": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/stream-to-observable/-/stream-to-observable-0.1.0.tgz",
-      "integrity": "sha1-Rb8dny19wJvtgfHDB8Qw5ouEz/4=",
-      "dev": true
-    },
-    "strict-uri-encode": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-      "dev": true
-    },
-    "string-length": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
-      "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
-      "dev": true,
-      "requires": {
-        "astral-regex": "1.0.0",
-        "strip-ansi": "4.0.0"
-      }
-    },
-    "string-template": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
-      "integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0="
-    },
-    "string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
-      }
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
-    "stringify-object": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.2.2.tgz",
-      "integrity": "sha512-O696NF21oLiDy8PhpWu8AEqoZHw++QW6mUv0UvKZe8gWSdSvMXkiLufK7OmnP27Dro4GU5kb9U7JIO0mBuCRQg==",
-      "dev": true,
-      "requires": {
-        "get-own-enumerable-property-symbols": "2.0.1",
-        "is-obj": "1.0.1",
-        "is-regexp": "1.0.0"
-      }
-    },
-    "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-      "dev": true
-    },
-    "strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-      "requires": {
-        "ansi-regex": "3.0.0"
-      }
-    },
-    "strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
-    },
-    "strip-bom-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz",
-      "integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
-      "requires": {
-        "first-chunk-stream": "2.0.0",
-        "strip-bom": "2.0.0"
-      },
-      "dependencies": {
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
-        }
-      }
-    },
-    "strip-eof": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-      "dev": true
-    },
-    "strip-indent": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-      "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
-      "dev": true
-    },
-    "strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "dev": true
-    },
-    "supports-color": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-      "requires": {
-        "has-flag": "3.0.0"
-      }
-    },
-    "symbol-observable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
-      "dev": true
-    },
-    "symbol-tree": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-      "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
-      "dev": true
-    },
-    "table": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
-      "dev": true,
-      "requires": {
-        "ajv": "5.5.2",
-        "ajv-keywords": "2.1.1",
-        "chalk": "2.4.0",
-        "lodash": "4.17.5",
-        "slice-ansi": "1.0.0",
-        "string-width": "2.1.1"
-      }
-    },
-    "taketalk": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/taketalk/-/taketalk-1.0.0.tgz",
-      "integrity": "sha1-tNTw3u0gauffd1sSnqLKbeUvJt0=",
-      "requires": {
-        "get-stdin": "4.0.1",
-        "minimist": "1.2.0"
-      }
-    },
-    "test-exclude": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.1.tgz",
-      "integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
-      "dev": true,
-      "requires": {
-        "arrify": "1.0.1",
-        "micromatch": "3.1.10",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "require-main-filename": "1.0.1"
-      },
-      "dependencies": {
-        "arr-diff": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-          "dev": true
-        },
-        "array-unique": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-          "dev": true
-        },
-        "braces": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "1.1.0",
-            "array-unique": "0.3.2",
-            "extend-shallow": "2.0.1",
-            "fill-range": "4.0.0",
-            "isobject": "3.0.1",
-            "repeat-element": "1.1.2",
-            "snapdragon": "0.8.2",
-            "snapdragon-node": "2.1.1",
-            "split-string": "3.1.0",
-            "to-regex": "3.0.2"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "0.1.1"
-              }
-            }
-          }
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "expand-brackets": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-          "dev": true,
-          "requires": {
-            "debug": "2.6.9",
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "posix-character-classes": "0.1.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "0.2.5",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-              "dev": true,
-              "requires": {
-                "is-descriptor": "0.1.6"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "0.1.1"
-              }
-            },
-            "is-accessor-descriptor": {
-              "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-              "dev": true,
-              "requires": {
-                "kind-of": "3.2.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "1.1.6"
-                  }
-                }
-              }
-            },
-            "is-data-descriptor": {
-              "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-              "dev": true,
-              "requires": {
-                "kind-of": "3.2.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "1.1.6"
-                  }
-                }
-              }
-            },
-            "is-descriptor": {
-              "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
-              }
-            },
-            "kind-of": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-              "dev": true
-            }
-          }
-        },
-        "extglob": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-          "dev": true,
-          "requires": {
-            "array-unique": "0.3.2",
-            "define-property": "1.0.0",
-            "expand-brackets": "2.1.4",
-            "extend-shallow": "2.0.1",
-            "fragment-cache": "0.2.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-              "dev": true,
-              "requires": {
-                "is-descriptor": "1.0.2"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "0.1.1"
-              }
-            }
-          }
-        },
-        "fill-range": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "2.0.1",
-            "is-number": "3.0.0",
-            "repeat-string": "1.6.1",
-            "to-regex-range": "2.1.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "0.1.1"
-              }
-            }
-          }
-        },
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-          "dev": true,
-          "requires": {
-            "kind-of": "6.0.2"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-          "dev": true,
-          "requires": {
-            "kind-of": "6.0.2"
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
-          }
-        },
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
-          }
-        },
-        "micromatch": {
-          "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-          "dev": true,
-          "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "braces": "2.3.2",
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "extglob": "2.0.4",
-            "fragment-cache": "0.2.1",
-            "kind-of": "6.0.2",
-            "nanomatch": "1.2.9",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
-          }
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "1.3.1"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "dev": true,
-          "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
-        }
-      }
-    },
-    "text-encoding": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
-      "dev": true
-    },
-    "text-extensions": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.7.0.tgz",
-      "integrity": "sha512-AKXZeDq230UaSzaO5s3qQUZOaC7iKbzq0jOFL614R7d9R593HLqAOL0cYoqLdkNrjBSOdmoQI06yigq1TSBXAg==",
-      "dev": true
-    },
-    "text-table": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
-    },
-    "textextensions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.2.0.tgz",
-      "integrity": "sha512-j5EMxnryTvKxwH2Cq+Pb43tsf6sdEgw6Pdwxk83mPaq0ToeFJt6WE4J3s5BqY7vmjlLgkgXvhtXUxo80FyBhCA=="
-    },
-    "throat": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
-      "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
-      "dev": true
-    },
-    "through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
-    },
-    "through2": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-      "requires": {
-        "readable-stream": "2.3.6",
-        "xtend": "4.0.1"
-      }
-    },
-    "timed-out": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
-    },
-    "tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "requires": {
-        "os-tmpdir": "1.0.2"
-      }
-    },
-    "tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
-      "dev": true
-    },
-    "to-fast-properties": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-      "dev": true
-    },
-    "to-object-path": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
-      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
-      "dev": true,
-      "requires": {
-        "kind-of": "3.2.2"
-      }
-    },
-    "to-regex": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
-      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
-      "dev": true,
-      "requires": {
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "regex-not": "1.0.2",
-        "safe-regex": "1.1.0"
-      }
-    },
-    "to-regex-range": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-      "dev": true,
-      "requires": {
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          }
-        }
-      }
-    },
-    "tough-cookie": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-      "dev": true,
-      "requires": {
-        "punycode": "1.4.1"
-      }
-    },
-    "tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
-      "dev": true
-    },
-    "travis-deploy-once": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/travis-deploy-once/-/travis-deploy-once-3.3.0.tgz",
-      "integrity": "sha512-N0l+sdYHMQbJmQWfjmxkKRJrMWJ+52Ve1dhGDiPhGXFiWO0A0zSeTxiFujz0rSOLOl9OhsZ9EMlJh2lNrgGugA==",
-      "dev": true,
-      "requires": {
-        "chalk": "2.4.0",
-        "got": "8.3.0",
-        "p-retry": "1.0.0",
-        "semver": "5.5.0",
-        "url-join": "2.0.5"
-      },
-      "dependencies": {
-        "got": {
-          "version": "8.3.0",
-          "resolved": "https://registry.npmjs.org/got/-/got-8.3.0.tgz",
-          "integrity": "sha512-kBNy/S2CGwrYgDSec5KTWGKUvupwkkTVAjIsVFF2shXO13xpZdFP4d4kxa//CLX2tN/rV0aYwK8vY6UKWGn2vQ==",
-          "dev": true,
-          "requires": {
-            "@sindresorhus/is": "0.7.0",
-            "cacheable-request": "2.1.4",
-            "decompress-response": "3.3.0",
-            "duplexer3": "0.1.4",
-            "get-stream": "3.0.0",
-            "into-stream": "3.1.0",
-            "is-retry-allowed": "1.1.0",
-            "isurl": "1.0.0",
-            "lowercase-keys": "1.0.1",
-            "mimic-response": "1.0.0",
-            "p-cancelable": "0.4.1",
-            "p-timeout": "2.0.1",
-            "pify": "3.0.0",
-            "safe-buffer": "5.1.1",
-            "timed-out": "4.0.1",
-            "url-parse-lax": "3.0.0",
-            "url-to-options": "1.0.1"
-          }
-        },
-        "p-cancelable": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
-          "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
-          "dev": true
-        },
-        "p-timeout": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
-          "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
-          "dev": true,
-          "requires": {
-            "p-finally": "1.0.0"
-          }
-        },
-        "prepend-http": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-          "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
-          "dev": true
-        },
-        "url-parse-lax": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-          "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
-          "dev": true,
-          "requires": {
-            "prepend-http": "2.0.0"
-          }
-        }
-      }
-    },
-    "trim-newlines": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-      "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
-      "dev": true
-    },
-    "trim-off-newlines": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
-      "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
-      "dev": true
-    },
-    "trim-right": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-      "dev": true
-    },
-    "tunnel-agent": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-      "dev": true
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true,
-      "optional": true
-    },
-    "type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "1.1.2"
-      }
-    },
-    "type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true
-    },
-    "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
-    },
-    "uglify-js": {
-      "version": "2.8.29",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
-      },
-      "dependencies": {
-        "yargs": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
-            "window-size": "0.1.0"
-          }
-        }
-      }
-    },
-    "uglify-to-browserify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "dev": true,
-      "optional": true
-    },
-    "uid-number": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz",
-      "integrity": "sha1-Wj2yPvXb1VuB/ODsmirG/M3ruB4=",
-      "dev": true
-    },
-    "union-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
-      "dev": true,
-      "requires": {
-        "arr-union": "3.1.0",
-        "get-value": "2.0.6",
-        "is-extendable": "0.1.1",
-        "set-value": "0.4.3"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "0.1.1"
-          }
-        },
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "to-object-path": "0.3.0"
-          }
-        }
-      }
-    },
-    "universalify": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
-      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
-      "dev": true
-    },
-    "unset-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
-      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
-      "dev": true,
-      "requires": {
-        "has-value": "0.3.1",
-        "isobject": "3.0.1"
-      },
-      "dependencies": {
-        "has-value": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
-          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-          "dev": true,
-          "requires": {
-            "get-value": "2.0.6",
-            "has-values": "0.1.4",
-            "isobject": "2.1.0"
-          },
-          "dependencies": {
-            "isobject": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-              "dev": true,
-              "requires": {
-                "isarray": "1.0.0"
-              }
-            }
-          }
-        },
-        "has-values": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
-          "dev": true
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        }
-      }
-    },
-    "untildify": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.2.tgz",
-      "integrity": "sha1-fx8wIFWz/qDz6B3HjrNnZstl4/E="
-    },
-    "unzip-response": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-      "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
-      "dev": true
-    },
-    "urix": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
-      "dev": true
-    },
-    "url-join": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.5.tgz",
-      "integrity": "sha1-WvIvGMBSoACkjXuCxenC4v7tpyg=",
-      "dev": true
-    },
-    "url-parse-lax": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-      "requires": {
-        "prepend-http": "1.0.4"
-      }
-    },
-    "url-to-options": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
-      "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
-    },
-    "use": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
-      "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
-      "dev": true,
-      "requires": {
-        "kind-of": "6.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
-        }
-      }
-    },
-    "user-home": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-      "dev": true,
-      "requires": {
-        "os-homedir": "1.0.2"
-      }
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-    },
-    "uuid": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
-      "dev": true
-    },
-    "validate-npm-package-license": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
-      "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
-      "requires": {
-        "spdx-correct": "3.0.0",
-        "spdx-expression-parse": "3.0.0"
-      }
-    },
-    "validate-npm-package-name": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
-      "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
-      "dev": true,
-      "requires": {
-        "builtins": "1.0.3"
-      }
-    },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
-      }
-    },
-    "vinyl": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
-      "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
-      "requires": {
-        "clone": "2.1.2",
-        "clone-buffer": "1.0.0",
-        "clone-stats": "1.0.0",
-        "cloneable-readable": "1.1.2",
-        "remove-trailing-separator": "1.1.0",
-        "replace-ext": "1.0.0"
-      }
-    },
-    "vinyl-file": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-2.0.0.tgz",
-      "integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0",
-        "strip-bom-stream": "2.0.0",
-        "vinyl": "1.2.0"
-      },
-      "dependencies": {
-        "clone": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
-        },
-        "clone-stats": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-          "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-        },
-        "replace-ext": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-          "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
-        },
-        "vinyl": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-          "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-          "requires": {
-            "clone": "1.0.4",
-            "clone-stats": "0.0.1",
-            "replace-ext": "0.0.1"
-          }
-        }
-      }
-    },
-    "walk": {
-      "version": "2.3.13",
-      "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.13.tgz",
-      "integrity": "sha512-78SMe7To9U7kqVhSoGho3GfspA089ZDBIj2f8jElg2hi6lUCoagtDJ8sSMFNlpAh5Ib8Jt1gQ6Y7gh9mzHtFng==",
-      "dev": true,
-      "requires": {
-        "foreachasync": "3.0.0"
-      }
-    },
-    "walker": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
-      "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
-      "dev": true,
-      "requires": {
-        "makeerror": "1.0.11"
-      }
-    },
-    "watch": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
-      "integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
-      "dev": true,
-      "requires": {
-        "exec-sh": "0.2.1",
-        "minimist": "1.2.0"
-      }
-    },
-    "webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-      "dev": true
-    },
-    "whatwg-encoding": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
-      "integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
-      "dev": true,
-      "requires": {
-        "iconv-lite": "0.4.19"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.4.19",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-          "dev": true
-        }
-      }
-    },
-    "whatwg-url": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
-      "integrity": "sha1-0pgaqRSMHgCkHFphMRZqtGg7vMA=",
-      "dev": true,
-      "requires": {
-        "tr46": "0.0.3",
-        "webidl-conversions": "3.0.1"
-      },
-      "dependencies": {
-        "webidl-conversions": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
-          "dev": true
-        }
-      }
-    },
-    "which": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-      "requires": {
-        "isexe": "2.0.0"
-      }
-    },
-    "which-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-      "dev": true
-    },
-    "wide-align": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-      "dev": true,
-      "requires": {
-        "string-width": "1.0.2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        }
-      }
-    },
-    "window-size": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-      "dev": true,
-      "optional": true
-    },
-    "wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-      "dev": true
-    },
-    "worker-farm": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.6.0.tgz",
-      "integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
-      "dev": true,
-      "requires": {
-        "errno": "0.1.7"
-      }
-    },
-    "wrap-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-      "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        }
-      }
-    },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
-    "write": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-      "dev": true,
-      "requires": {
-        "mkdirp": "0.5.1"
-      }
-    },
-    "write-file-atomic": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-      "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "imurmurhash": "0.1.4",
-        "signal-exit": "3.0.2"
-      }
-    },
-    "xml-name-validator": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
-      "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
-      "dev": true
-    },
-    "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-    },
-    "y18n": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-      "dev": true
-    },
-    "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-    },
-    "yargs": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
-      "integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
-      "dev": true,
-      "requires": {
-        "camelcase": "4.1.0",
-        "cliui": "3.2.0",
-        "decamelize": "1.2.0",
-        "get-caller-file": "1.0.2",
-        "os-locale": "2.1.0",
-        "read-pkg-up": "2.0.0",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "2.1.1",
-        "which-module": "2.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "7.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
+        "cli-width": {
+            "version": "2.2.0",
+            "resolved":
+                "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+            "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
         },
         "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "dev": true,
-          "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
-          },
-          "dependencies": {
-            "string-width": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "dev": true,
-              "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
-              }
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+            "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "center-align": "0.1.3",
+                "right-align": "0.1.3",
+                "wordwrap": "0.0.2"
+            },
+            "dependencies": {
+                "wordwrap": {
+                    "version": "0.0.2",
+                    "resolved":
+                        "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                    "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+                    "dev": true,
+                    "optional": true
+                }
             }
-          }
         },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
+        "clone": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+            "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
         },
-        "load-json-file": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "strip-bom": "3.0.0"
-          }
+        "clone-buffer": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+            "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg="
         },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "1.3.1"
-          }
+        "clone-stats": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+            "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
         },
-        "path-type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-          "dev": true,
-          "requires": {
-            "pify": "2.3.0"
-          }
+        "cloneable-readable": {
+            "version": "1.1.2",
+            "resolved":
+                "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
+            "integrity":
+                "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
+            "requires": {
+                "inherits": "2.0.3",
+                "process-nextick-args": "2.0.0",
+                "readable-stream": "2.3.6"
+            }
         },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
+        "co": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+            "dev": true
         },
-        "read-pkg": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "2.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "2.0.0"
-          }
+        "code-point-at": {
+            "version": "1.1.0",
+            "resolved":
+                "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
-        "read-pkg-up": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "dev": true,
-          "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "2.0.0"
-          }
+        "collection-visit": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+            "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+            "requires": {
+                "map-visit": "1.0.0",
+                "object-visit": "1.0.1"
+            }
         },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        }
-      }
-    },
-    "yargs-parser": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-      "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-      "dev": true,
-      "requires": {
-        "camelcase": "4.1.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
-        }
-      }
-    },
-    "yeoman-assert": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yeoman-assert/-/yeoman-assert-3.1.1.tgz",
-      "integrity": "sha512-bCuLb/j/WzpvrJZCTdJJLFzm7KK8IYQJ3+dF9dYtNs2CUYyezFJDuULiZ2neM4eqjf45GN1KH/MzCTT3i90wUQ==",
-      "dev": true
-    },
-    "yeoman-environment": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.0.6.tgz",
-      "integrity": "sha512-jzHBTTy8EPI4ImV8dpUMt+Q5zELkSU5xvGpndHcHudQ4tqN6YgIWaCGmRFl+HDchwRUkcgyjQ+n6/w5zlJBCPg==",
-      "requires": {
-        "chalk": "2.4.0",
-        "debug": "3.1.0",
-        "diff": "3.5.0",
-        "escape-string-regexp": "1.0.5",
-        "globby": "6.1.0",
-        "grouped-queue": "0.3.3",
-        "inquirer": "3.3.0",
-        "is-scoped": "1.0.0",
-        "lodash": "4.17.5",
-        "log-symbols": "2.2.0",
-        "mem-fs": "1.1.3",
-        "text-table": "0.2.0",
-        "untildify": "3.0.2"
-      }
-    },
-    "yeoman-generator": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-2.0.4.tgz",
-      "integrity": "sha512-Sgvz3MAkOpEIobcpW3rjEl6bOTNnl8SkibP9z7hYKfIGIlw0QDC2k0MAeXvyE2pLqc2M0Duql+6R7/W9GrJojg==",
-      "requires": {
-        "async": "2.6.0",
-        "chalk": "2.4.0",
-        "cli-table": "0.3.1",
-        "cross-spawn": "5.1.0",
-        "dargs": "5.1.0",
-        "dateformat": "3.0.3",
-        "debug": "3.1.0",
-        "detect-conflict": "1.0.1",
-        "error": "7.0.2",
-        "find-up": "2.1.0",
-        "github-username": "4.1.0",
-        "istextorbinary": "2.2.1",
-        "lodash": "4.17.5",
-        "make-dir": "1.2.0",
-        "mem-fs-editor": "3.0.2",
-        "minimist": "1.2.0",
-        "pretty-bytes": "4.0.2",
-        "read-chunk": "2.1.0",
-        "read-pkg-up": "3.0.0",
-        "rimraf": "2.6.2",
-        "run-async": "2.3.0",
-        "shelljs": "0.8.1",
-        "text-table": "0.2.0",
-        "through2": "2.0.3",
-        "yeoman-environment": "2.0.6"
-      }
-    },
-    "yeoman-test": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/yeoman-test/-/yeoman-test-1.7.0.tgz",
-      "integrity": "sha512-vJeg2gpWfhbq0HvQ7/yqmsQpYmADBfo9kaW+J6uJASkI7ChLBXNLIBQqaXCA65kWtHXOco+nBm0Km/O9YWk25Q==",
-      "dev": true,
-      "requires": {
-        "inquirer": "3.3.0",
-        "lodash": "4.17.5",
-        "mkdirp": "0.5.1",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2",
-        "sinon": "2.4.1",
-        "yeoman-environment": "2.0.6",
-        "yeoman-generator": "1.1.1"
-      },
-      "dependencies": {
-        "ansi-escapes": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
-          "dev": true
+        "color-convert": {
+            "version": "1.9.1",
+            "resolved":
+                "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+            "integrity":
+                "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+            "requires": {
+                "color-name": "1.1.3"
+            }
         },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+        "color-name": {
+            "version": "1.1.3",
+            "resolved":
+                "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
+        "colors": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+            "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
         },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
+        "combined-stream": {
+            "version": "1.0.6",
+            "resolved":
+                "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+            "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+            "dev": true,
+            "requires": {
+                "delayed-stream": "1.0.0"
+            }
         },
-        "cli-cursor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-          "dev": true,
-          "requires": {
-            "restore-cursor": "1.0.1"
-          }
+        "commander": {
+            "version": "2.15.1",
+            "resolved":
+                "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+            "integrity":
+                "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+            "dev": true
+        },
+        "commitizen": {
+            "version": "2.9.6",
+            "resolved":
+                "https://registry.npmjs.org/commitizen/-/commitizen-2.9.6.tgz",
+            "integrity": "sha1-wNAFNe8mTaf2Nzft/aQiiYP6IpE=",
+            "dev": true,
+            "requires": {
+                "cachedir": "1.2.0",
+                "chalk": "1.1.3",
+                "cz-conventional-changelog": "1.2.0",
+                "dedent": "0.6.0",
+                "detect-indent": "4.0.0",
+                "find-node-modules": "1.0.4",
+                "find-root": "1.0.0",
+                "fs-extra": "1.0.0",
+                "glob": "7.1.1",
+                "inquirer": "1.2.3",
+                "lodash": "4.17.2",
+                "minimist": "1.2.0",
+                "path-exists": "2.1.0",
+                "shelljs": "0.7.6",
+                "strip-json-comments": "2.0.1"
+            },
+            "dependencies": {
+                "ansi-escapes": {
+                    "version": "1.4.0",
+                    "resolved":
+                        "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+                    "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+                    "dev": true
+                },
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved":
+                        "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved":
+                        "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved":
+                        "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
+                    }
+                },
+                "cli-cursor": {
+                    "version": "1.0.2",
+                    "resolved":
+                        "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+                    "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+                    "dev": true,
+                    "requires": {
+                        "restore-cursor": "1.0.1"
+                    }
+                },
+                "cz-conventional-changelog": {
+                    "version": "1.2.0",
+                    "resolved":
+                        "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-1.2.0.tgz",
+                    "integrity": "sha1-K8oElkyJGbI/P9aonvXmAIsxs/g=",
+                    "dev": true,
+                    "requires": {
+                        "conventional-commit-types": "2.2.0",
+                        "lodash.map": "4.6.0",
+                        "longest": "1.0.1",
+                        "pad-right": "0.2.2",
+                        "right-pad": "1.0.1",
+                        "word-wrap": "1.2.3"
+                    }
+                },
+                "external-editor": {
+                    "version": "1.1.1",
+                    "resolved":
+                        "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
+                    "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
+                    "dev": true,
+                    "requires": {
+                        "extend": "3.0.1",
+                        "spawn-sync": "1.0.15",
+                        "tmp": "0.0.29"
+                    }
+                },
+                "figures": {
+                    "version": "1.7.0",
+                    "resolved":
+                        "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+                    "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+                    "dev": true,
+                    "requires": {
+                        "escape-string-regexp": "1.0.5",
+                        "object-assign": "4.1.1"
+                    }
+                },
+                "glob": {
+                    "version": "7.1.1",
+                    "resolved":
+                        "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+                    "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
+                },
+                "inquirer": {
+                    "version": "1.2.3",
+                    "resolved":
+                        "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
+                    "integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-escapes": "1.4.0",
+                        "chalk": "1.1.3",
+                        "cli-cursor": "1.0.2",
+                        "cli-width": "2.2.0",
+                        "external-editor": "1.1.1",
+                        "figures": "1.7.0",
+                        "lodash": "4.17.2",
+                        "mute-stream": "0.0.6",
+                        "pinkie-promise": "2.0.1",
+                        "run-async": "2.3.0",
+                        "rx": "4.1.0",
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1",
+                        "through": "2.3.8"
+                    }
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                    "dev": true,
+                    "requires": {
+                        "number-is-nan": "1.0.1"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.2",
+                    "resolved":
+                        "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
+                    "integrity": "sha1-NKMFW6vgTOQkZ7YH1wAHLH/2v0I=",
+                    "dev": true
+                },
+                "mute-stream": {
+                    "version": "0.0.6",
+                    "resolved":
+                        "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
+                    "integrity": "sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s=",
+                    "dev": true
+                },
+                "onetime": {
+                    "version": "1.1.0",
+                    "resolved":
+                        "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+                    "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+                    "dev": true
+                },
+                "path-exists": {
+                    "version": "2.1.0",
+                    "resolved":
+                        "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+                    "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+                    "dev": true,
+                    "requires": {
+                        "pinkie-promise": "2.0.1"
+                    }
+                },
+                "restore-cursor": {
+                    "version": "1.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+                    "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+                    "dev": true,
+                    "requires": {
+                        "exit-hook": "1.1.1",
+                        "onetime": "1.1.0"
+                    }
+                },
+                "shelljs": {
+                    "version": "0.7.6",
+                    "resolved":
+                        "https://registry.npmjs.org/shelljs/-/shelljs-0.7.6.tgz",
+                    "integrity": "sha1-N5zM+1a5HIYB5HkzVutTgpJN6a0=",
+                    "dev": true,
+                    "requires": {
+                        "glob": "7.1.1",
+                        "interpret": "1.1.0",
+                        "rechoir": "0.6.2"
+                    }
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "resolved":
+                        "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                    "dev": true,
+                    "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                },
+                "tmp": {
+                    "version": "0.0.29",
+                    "resolved":
+                        "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
+                    "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
+                    "dev": true,
+                    "requires": {
+                        "os-tmpdir": "1.0.2"
+                    }
+                }
+            }
+        },
+        "commondir": {
+            "version": "1.0.1",
+            "resolved":
+                "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+            "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
+        },
+        "compare-func": {
+            "version": "1.3.2",
+            "resolved":
+                "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
+            "integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
+            "dev": true,
+            "requires": {
+                "array-ify": "1.0.0",
+                "dot-prop": "3.0.0"
+            }
+        },
+        "compare-versions": {
+            "version": "3.2.1",
+            "resolved":
+                "https://registry.npmjs.org/compare-versions/-/compare-versions-3.2.1.tgz",
+            "integrity":
+                "sha512-2y2nHcopMG/NAyk6vWXlLs86XeM9sik4jmx1tKIgzMi9/RQ2eo758RGpxQO3ErihHmg0RlQITPqgz73y6s7quA==",
+            "dev": true
+        },
+        "component-emitter": {
+            "version": "1.2.1",
+            "resolved":
+                "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+            "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved":
+                "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+        },
+        "concat-stream": {
+            "version": "1.6.2",
+            "resolved":
+                "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+            "integrity":
+                "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+            "dev": true,
+            "requires": {
+                "buffer-from": "1.0.0",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6",
+                "typedarray": "0.0.6"
+            }
+        },
+        "conventional-changelog-angular": {
+            "version": "3.0.7",
+            "resolved":
+                "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-3.0.7.tgz",
+            "integrity":
+                "sha512-I1W7Vr/2AFlwhrjvjhp8Tz61qsRWc/dL96kgMmAwkJw/eVLLTokbuYnyYQ8k+/Loy2na8C18yD0SOkE/1AmIsw==",
+            "dev": true,
+            "requires": {
+                "compare-func": "1.3.2",
+                "q": "1.5.1"
+            }
+        },
+        "conventional-changelog-writer": {
+            "version": "3.0.9",
+            "resolved":
+                "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-3.0.9.tgz",
+            "integrity":
+                "sha512-n9KbsxlJxRQsUnK6wIBRnARacvNnN4C/nxnxCkH+B/R1JS2Fa+DiP1dU4I59mEDEjgnFaN2+9wr1P1s7GYB5/Q==",
+            "dev": true,
+            "requires": {
+                "compare-func": "1.3.2",
+                "conventional-commits-filter": "1.1.6",
+                "dateformat": "3.0.3",
+                "handlebars": "4.0.11",
+                "json-stringify-safe": "5.0.1",
+                "lodash": "4.17.10",
+                "meow": "4.0.1",
+                "semver": "5.5.0",
+                "split": "1.0.1",
+                "through2": "2.0.3"
+            }
+        },
+        "conventional-commit-types": {
+            "version": "2.2.0",
+            "resolved":
+                "https://registry.npmjs.org/conventional-commit-types/-/conventional-commit-types-2.2.0.tgz",
+            "integrity": "sha1-XblXOdbCEqy+e29lahG5QLqmiUY=",
+            "dev": true
+        },
+        "conventional-commits-filter": {
+            "version": "1.1.6",
+            "resolved":
+                "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.1.6.tgz",
+            "integrity":
+                "sha512-KcDgtCRKJCQhyk6VLT7zR+ZOyCnerfemE/CsR3iQpzRRFbLEs0Y6rwk3mpDvtOh04X223z+1xyJ582Stfct/0Q==",
+            "dev": true,
+            "requires": {
+                "is-subset": "0.1.1",
+                "modify-values": "1.0.1"
+            }
+        },
+        "conventional-commits-parser": {
+            "version": "2.1.7",
+            "resolved":
+                "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.7.tgz",
+            "integrity":
+                "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
+            "dev": true,
+            "requires": {
+                "is-text-path": "1.0.1",
+                "JSONStream": "1.3.2",
+                "lodash": "4.17.10",
+                "meow": "4.0.1",
+                "split2": "2.2.0",
+                "through2": "2.0.3",
+                "trim-off-newlines": "1.0.1"
+            }
+        },
+        "convert-source-map": {
+            "version": "1.5.1",
+            "resolved":
+                "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+            "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+            "dev": true
+        },
+        "copy-descriptor": {
+            "version": "0.1.1",
+            "resolved":
+                "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+            "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+        },
+        "core-js": {
+            "version": "2.5.6",
+            "resolved":
+                "https://registry.npmjs.org/core-js/-/core-js-2.5.6.tgz",
+            "integrity":
+                "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ==",
+            "dev": true
+        },
+        "core-util-is": {
+            "version": "1.0.2",
+            "resolved":
+                "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+        },
+        "cosmiconfig": {
+            "version": "4.0.0",
+            "resolved":
+                "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
+            "integrity":
+                "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
+            "dev": true,
+            "requires": {
+                "is-directory": "0.3.1",
+                "js-yaml": "3.11.0",
+                "parse-json": "4.0.0",
+                "require-from-string": "2.0.2"
+            }
+        },
+        "coveralls": {
+            "version": "3.0.1",
+            "resolved":
+                "https://registry.npmjs.org/coveralls/-/coveralls-3.0.1.tgz",
+            "integrity":
+                "sha512-FAzXwiDOYLGDWH+zgoIA+8GbWv50hlx+kpEJyvzLKOdnIBv9uWoVl4DhqGgyUHpiRjAlF8KYZSipWXYtllWH6Q==",
+            "dev": true,
+            "requires": {
+                "js-yaml": "3.11.0",
+                "lcov-parse": "0.0.10",
+                "log-driver": "1.2.7",
+                "minimist": "1.2.0",
+                "request": "2.86.0"
+            }
+        },
+        "cross-env": {
+            "version": "5.1.5",
+            "resolved":
+                "https://registry.npmjs.org/cross-env/-/cross-env-5.1.5.tgz",
+            "integrity":
+                "sha512-GSiNTbvTU3pXzewRKGP0Y+rVP2CzifY2pqSEdtHzLLj41pRdkrgY7e4uSnBoR/pmYaqZr/lwwjg/Q4kNX30hWQ==",
+            "dev": true,
+            "requires": {
+                "cross-spawn": "5.1.0",
+                "is-windows": "1.0.2"
+            },
+            "dependencies": {
+                "cross-spawn": {
+                    "version": "5.1.0",
+                    "resolved":
+                        "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+                    "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "4.1.3",
+                        "shebang-command": "1.2.0",
+                        "which": "1.3.0"
+                    }
+                }
+            }
+        },
+        "cross-spawn": {
+            "version": "6.0.5",
+            "resolved":
+                "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+            "integrity":
+                "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+            "requires": {
+                "nice-try": "1.0.4",
+                "path-key": "2.0.1",
+                "semver": "5.5.0",
+                "shebang-command": "1.2.0",
+                "which": "1.3.0"
+            }
+        },
+        "cryptiles": {
+            "version": "3.1.2",
+            "resolved":
+                "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+            "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+            "dev": true,
+            "requires": {
+                "boom": "5.2.0"
+            },
+            "dependencies": {
+                "boom": {
+                    "version": "5.2.0",
+                    "resolved":
+                        "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+                    "integrity":
+                        "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+                    "dev": true,
+                    "requires": {
+                        "hoek": "4.2.1"
+                    }
+                }
+            }
+        },
+        "cssom": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
+            "integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs=",
+            "dev": true
+        },
+        "cssstyle": {
+            "version": "0.2.37",
+            "resolved":
+                "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
+            "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+            "dev": true,
+            "requires": {
+                "cssom": "0.3.2"
+            }
+        },
+        "currently-unhandled": {
+            "version": "0.4.1",
+            "resolved":
+                "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+            "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+            "dev": true,
+            "requires": {
+                "array-find-index": "1.0.2"
+            }
+        },
+        "cvss": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/cvss/-/cvss-1.0.2.tgz",
+            "integrity": "sha1-32fpK/EqeW9J6Sh5nI2zunS5/NY=",
+            "dev": true
+        },
+        "cz-conventional-changelog": {
+            "version": "2.1.0",
+            "resolved":
+                "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-2.1.0.tgz",
+            "integrity": "sha1-L0vHOQ4yROTfKT5ro1Hkx0Cnx2Q=",
+            "dev": true,
+            "requires": {
+                "conventional-commit-types": "2.2.0",
+                "lodash.map": "4.6.0",
+                "longest": "1.0.1",
+                "right-pad": "1.0.1",
+                "word-wrap": "1.2.3"
+            }
+        },
+        "dargs": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/dargs/-/dargs-5.1.0.tgz",
+            "integrity": "sha1-7H6lDHhWTNNsnV7Bj2Yyn63ieCk="
+        },
+        "dashdash": {
+            "version": "1.14.1",
+            "resolved":
+                "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0"
+            }
+        },
+        "data-urls": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/data-urls/-/data-urls-1.0.0.tgz",
+            "integrity":
+                "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
+            "dev": true,
+            "requires": {
+                "abab": "1.0.4",
+                "whatwg-mimetype": "2.1.0",
+                "whatwg-url": "6.4.1"
+            }
+        },
+        "date-fns": {
+            "version": "1.29.0",
+            "resolved":
+                "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
+            "integrity":
+                "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
+            "dev": true
         },
         "dateformat": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
-          "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
-          "dev": true
+            "version": "3.0.3",
+            "resolved":
+                "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+            "integrity":
+                "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
         },
         "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+            "integrity":
+                "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+            "requires": {
+                "ms": "2.0.0"
+            }
+        },
+        "decamelize": {
+            "version": "1.2.0",
+            "resolved":
+                "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "dev": true
+        },
+        "decamelize-keys": {
+            "version": "1.1.0",
+            "resolved":
+                "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+            "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+            "dev": true,
+            "requires": {
+                "decamelize": "1.2.0",
+                "map-obj": "1.0.1"
+            },
+            "dependencies": {
+                "map-obj": {
+                    "version": "1.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                    "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+                    "dev": true
+                }
+            }
+        },
+        "decode-uri-component": {
+            "version": "0.2.0",
+            "resolved":
+                "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+        },
+        "decompress-response": {
+            "version": "3.3.0",
+            "resolved":
+                "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+            "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+            "requires": {
+                "mimic-response": "1.0.0"
+            }
+        },
+        "dedent": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.6.0.tgz",
+            "integrity": "sha1-Dm2o8M5Sg471zsXI+TlrDBtko8s=",
+            "dev": true
+        },
+        "deep-extend": {
+            "version": "0.5.1",
+            "resolved":
+                "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+            "integrity":
+                "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w=="
+        },
+        "deep-is": {
+            "version": "0.1.3",
+            "resolved":
+                "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+            "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+            "dev": true
+        },
+        "default-require-extensions": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
+            "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+            "dev": true,
+            "requires": {
+                "strip-bom": "2.0.0"
+            },
+            "dependencies": {
+                "strip-bom": {
+                    "version": "2.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                    "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+                    "dev": true,
+                    "requires": {
+                        "is-utf8": "0.2.1"
+                    }
+                }
+            }
+        },
+        "define-properties": {
+            "version": "1.1.2",
+            "resolved":
+                "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+            "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+            "dev": true,
+            "requires": {
+                "foreach": "2.0.5",
+                "object-keys": "1.0.11"
+            }
+        },
+        "define-property": {
+            "version": "2.0.2",
+            "resolved":
+                "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+            "integrity":
+                "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+            "requires": {
+                "is-descriptor": "1.0.2",
+                "isobject": "3.0.1"
+            },
+            "dependencies": {
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity":
+                        "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "requires": {
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity":
+                        "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "requires": {
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved":
+                        "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity":
+                        "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "requires": {
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
+                    }
+                }
+            }
+        },
+        "del": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+            "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+            "dev": true,
+            "requires": {
+                "globby": "5.0.0",
+                "is-path-cwd": "1.0.0",
+                "is-path-in-cwd": "1.0.1",
+                "object-assign": "4.1.1",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1",
+                "rimraf": "2.6.2"
+            },
+            "dependencies": {
+                "globby": {
+                    "version": "5.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+                    "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+                    "dev": true,
+                    "requires": {
+                        "array-union": "1.0.2",
+                        "arrify": "1.0.1",
+                        "glob": "7.1.2",
+                        "object-assign": "4.1.1",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1"
+                    }
+                },
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved":
+                        "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                    "dev": true
+                }
+            }
+        },
+        "delayed-stream": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+            "dev": true
+        },
+        "detect-conflict": {
+            "version": "1.0.1",
+            "resolved":
+                "https://registry.npmjs.org/detect-conflict/-/detect-conflict-1.0.1.tgz",
+            "integrity": "sha1-CIZXpmqWHAUBnbfEIwiDsca0F24="
+        },
+        "detect-file": {
+            "version": "0.1.0",
+            "resolved":
+                "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
+            "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
+            "dev": true,
+            "requires": {
+                "fs-exists-sync": "0.1.0"
+            }
+        },
+        "detect-indent": {
+            "version": "4.0.0",
+            "resolved":
+                "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+            "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+            "dev": true,
+            "requires": {
+                "repeating": "2.0.1"
+            }
+        },
+        "detect-newline": {
+            "version": "2.1.0",
+            "resolved":
+                "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+            "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
+            "dev": true
         },
         "diff": {
-          "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
-          "integrity": "sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k=",
-          "dev": true
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+            "integrity":
+                "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+        },
+        "dir-glob": {
+            "version": "2.0.0",
+            "resolved":
+                "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
+            "integrity":
+                "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
+            "requires": {
+                "arrify": "1.0.1",
+                "path-type": "3.0.0"
+            }
+        },
+        "doctrine": {
+            "version": "2.1.0",
+            "resolved":
+                "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+            "integrity":
+                "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+            "dev": true,
+            "requires": {
+                "esutils": "2.0.2"
+            }
+        },
+        "domexception": {
+            "version": "1.0.1",
+            "resolved":
+                "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+            "integrity":
+                "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+            "dev": true,
+            "requires": {
+                "webidl-conversions": "4.0.2"
+            }
+        },
+        "dot-prop": {
+            "version": "3.0.0",
+            "resolved":
+                "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
+            "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
+            "dev": true,
+            "requires": {
+                "is-obj": "1.0.1"
+            }
+        },
+        "duplexer2": {
+            "version": "0.1.4",
+            "resolved":
+                "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+            "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "2.3.6"
+            }
+        },
+        "duplexer3": {
+            "version": "0.1.4",
+            "resolved":
+                "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+            "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+        },
+        "ecc-jsbn": {
+            "version": "0.1.1",
+            "resolved":
+                "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+            "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "jsbn": "0.1.1"
+            }
+        },
+        "editions": {
+            "version": "1.3.4",
+            "resolved":
+                "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+            "integrity":
+                "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
+        },
+        "ejs": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
+            "integrity":
+                "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ=="
+        },
+        "elegant-spinner": {
+            "version": "1.0.1",
+            "resolved":
+                "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+            "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
+            "dev": true
+        },
+        "env-ci": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-2.1.0.tgz",
+            "integrity":
+                "sha512-ekorGVu0ubSzShUdyALj9y/4GRyaupvf8yKgbUDvR8FClHpVmg36v0oYzZj2MsZh44T80PcUWzcwkhbsR+eyvw==",
+            "dev": true,
+            "requires": {
+                "execa": "0.10.0",
+                "java-properties": "0.2.10"
+            },
+            "dependencies": {
+                "execa": {
+                    "version": "0.10.0",
+                    "resolved":
+                        "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+                    "integrity":
+                        "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "6.0.5",
+                        "get-stream": "3.0.0",
+                        "is-stream": "1.1.0",
+                        "npm-run-path": "2.0.2",
+                        "p-finally": "1.0.0",
+                        "signal-exit": "3.0.2",
+                        "strip-eof": "1.0.0"
+                    }
+                }
+            }
+        },
+        "error": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/error/-/error-7.0.2.tgz",
+            "integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
+            "requires": {
+                "string-template": "0.2.1",
+                "xtend": "4.0.1"
+            }
+        },
+        "error-ex": {
+            "version": "1.3.1",
+            "resolved":
+                "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+            "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+            "requires": {
+                "is-arrayish": "0.2.1"
+            }
+        },
+        "es-abstract": {
+            "version": "1.11.0",
+            "resolved":
+                "https://registry.npmjs.org/es-abstract/-/es-abstract-1.11.0.tgz",
+            "integrity":
+                "sha512-ZnQrE/lXTTQ39ulXZ+J1DTFazV9qBy61x2bY071B+qGco8Z8q1QddsLdt/EF8Ai9hcWH72dWS0kFqXLxOxqslA==",
+            "dev": true,
+            "requires": {
+                "es-to-primitive": "1.1.1",
+                "function-bind": "1.1.1",
+                "has": "1.0.1",
+                "is-callable": "1.1.3",
+                "is-regex": "1.0.4"
+            }
+        },
+        "es-to-primitive": {
+            "version": "1.1.1",
+            "resolved":
+                "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+            "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+            "dev": true,
+            "requires": {
+                "is-callable": "1.1.3",
+                "is-date-object": "1.0.1",
+                "is-symbol": "1.0.1"
+            }
+        },
+        "es6-promise": {
+            "version": "4.2.4",
+            "resolved":
+                "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+            "integrity":
+                "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
+            "dev": true
+        },
+        "es6-promisify": {
+            "version": "5.0.0",
+            "resolved":
+                "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+            "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+            "dev": true,
+            "requires": {
+                "es6-promise": "4.2.4"
+            }
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved":
+                "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+        },
+        "escodegen": {
+            "version": "1.9.1",
+            "resolved":
+                "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
+            "integrity":
+                "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
+            "dev": true,
+            "requires": {
+                "esprima": "3.1.3",
+                "estraverse": "4.2.0",
+                "esutils": "2.0.2",
+                "optionator": "0.8.2",
+                "source-map": "0.6.1"
+            },
+            "dependencies": {
+                "esprima": {
+                    "version": "3.1.3",
+                    "resolved":
+                        "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+                    "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved":
+                        "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity":
+                        "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true,
+                    "optional": true
+                }
+            }
+        },
+        "eslint": {
+            "version": "4.19.1",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+            "integrity":
+                "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+            "dev": true,
+            "requires": {
+                "ajv": "5.5.2",
+                "babel-code-frame": "6.26.0",
+                "chalk": "2.4.1",
+                "concat-stream": "1.6.2",
+                "cross-spawn": "5.1.0",
+                "debug": "3.1.0",
+                "doctrine": "2.1.0",
+                "eslint-scope": "3.7.1",
+                "eslint-visitor-keys": "1.0.0",
+                "espree": "3.5.4",
+                "esquery": "1.0.1",
+                "esutils": "2.0.2",
+                "file-entry-cache": "2.0.0",
+                "functional-red-black-tree": "1.0.1",
+                "glob": "7.1.2",
+                "globals": "11.5.0",
+                "ignore": "3.3.8",
+                "imurmurhash": "0.1.4",
+                "inquirer": "3.3.0",
+                "is-resolvable": "1.1.0",
+                "js-yaml": "3.11.0",
+                "json-stable-stringify-without-jsonify": "1.0.1",
+                "levn": "0.3.0",
+                "lodash": "4.17.10",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "natural-compare": "1.4.0",
+                "optionator": "0.8.2",
+                "path-is-inside": "1.0.2",
+                "pluralize": "7.0.0",
+                "progress": "2.0.0",
+                "regexpp": "1.1.0",
+                "require-uncached": "1.0.3",
+                "semver": "5.5.0",
+                "strip-ansi": "4.0.0",
+                "strip-json-comments": "2.0.1",
+                "table": "4.0.2",
+                "text-table": "0.2.0"
+            },
+            "dependencies": {
+                "cross-spawn": {
+                    "version": "5.1.0",
+                    "resolved":
+                        "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+                    "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "4.1.3",
+                        "shebang-command": "1.2.0",
+                        "which": "1.3.0"
+                    }
+                },
+                "inquirer": {
+                    "version": "3.3.0",
+                    "resolved":
+                        "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+                    "integrity":
+                        "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-escapes": "3.1.0",
+                        "chalk": "2.4.1",
+                        "cli-cursor": "2.1.0",
+                        "cli-width": "2.2.0",
+                        "external-editor": "2.2.0",
+                        "figures": "2.0.0",
+                        "lodash": "4.17.10",
+                        "mute-stream": "0.0.7",
+                        "run-async": "2.3.0",
+                        "rx-lite": "4.0.8",
+                        "rx-lite-aggregates": "4.0.8",
+                        "string-width": "2.1.1",
+                        "strip-ansi": "4.0.0",
+                        "through": "2.3.8"
+                    }
+                }
+            }
+        },
+        "eslint-config-prettier": {
+            "version": "2.9.0",
+            "resolved":
+                "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-2.9.0.tgz",
+            "integrity":
+                "sha512-ag8YEyBXsm3nmOv1Hz991VtNNDMRa+MNy8cY47Pl4bw6iuzqKbJajXdqUpiw13STdLLrznxgm1hj9NhxeOYq0A==",
+            "dev": true,
+            "requires": {
+                "get-stdin": "5.0.1"
+            },
+            "dependencies": {
+                "get-stdin": {
+                    "version": "5.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+                    "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
+                    "dev": true
+                }
+            }
+        },
+        "eslint-config-xo": {
+            "version": "0.20.1",
+            "resolved":
+                "https://registry.npmjs.org/eslint-config-xo/-/eslint-config-xo-0.20.1.tgz",
+            "integrity":
+                "sha512-bhDRezvlbYNZn8SHv0WE8aPsdPtH3sq1IU2SznyOtmRwi6e/XQkzs+Kaw1hA9Pz4xmkG796egIsFY2RD6fwUeQ==",
+            "dev": true
+        },
+        "eslint-plugin-prettier": {
+            "version": "2.6.0",
+            "resolved":
+                "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.0.tgz",
+            "integrity":
+                "sha512-floiaI4F7hRkTrFe8V2ItOK97QYrX75DjmdzmVITZoAP6Cn06oEDPQRsO6MlHEP/u2SxI3xQ52Kpjw6j5WGfeQ==",
+            "dev": true,
+            "requires": {
+                "fast-diff": "1.1.2",
+                "jest-docblock": "21.2.0"
+            }
+        },
+        "eslint-scope": {
+            "version": "3.7.1",
+            "resolved":
+                "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+            "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+            "dev": true,
+            "requires": {
+                "esrecurse": "4.2.1",
+                "estraverse": "4.2.0"
+            }
+        },
+        "eslint-visitor-keys": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+            "integrity":
+                "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+            "dev": true
+        },
+        "espree": {
+            "version": "3.5.4",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+            "integrity":
+                "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+            "dev": true,
+            "requires": {
+                "acorn": "5.5.3",
+                "acorn-jsx": "3.0.1"
+            }
+        },
+        "esprima": {
+            "version": "4.0.0",
+            "resolved":
+                "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+            "integrity":
+                "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+            "dev": true
+        },
+        "esquery": {
+            "version": "1.0.1",
+            "resolved":
+                "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+            "integrity":
+                "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+            "dev": true,
+            "requires": {
+                "estraverse": "4.2.0"
+            }
+        },
+        "esrecurse": {
+            "version": "4.2.1",
+            "resolved":
+                "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+            "integrity":
+                "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+            "dev": true,
+            "requires": {
+                "estraverse": "4.2.0"
+            }
+        },
+        "estraverse": {
+            "version": "4.2.0",
+            "resolved":
+                "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+            "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+            "dev": true
+        },
+        "esutils": {
+            "version": "2.0.2",
+            "resolved":
+                "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+            "dev": true
+        },
+        "exec-sh": {
+            "version": "0.2.1",
+            "resolved":
+                "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
+            "integrity":
+                "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
+            "dev": true,
+            "requires": {
+                "merge": "1.2.0"
+            }
+        },
+        "execa": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+            "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+            "dev": true,
+            "requires": {
+                "cross-spawn": "5.1.0",
+                "get-stream": "3.0.0",
+                "is-stream": "1.1.0",
+                "npm-run-path": "2.0.2",
+                "p-finally": "1.0.0",
+                "signal-exit": "3.0.2",
+                "strip-eof": "1.0.0"
+            },
+            "dependencies": {
+                "cross-spawn": {
+                    "version": "5.1.0",
+                    "resolved":
+                        "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+                    "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "4.1.3",
+                        "shebang-command": "1.2.0",
+                        "which": "1.3.0"
+                    }
+                }
+            }
+        },
+        "exit": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+            "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+            "dev": true
+        },
+        "exit-hook": {
+            "version": "1.1.1",
+            "resolved":
+                "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+            "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+            "dev": true
+        },
+        "expand-brackets": {
+            "version": "2.1.4",
+            "resolved":
+                "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+            "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+            "requires": {
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "posix-character-classes": "0.1.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved":
+                        "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity":
+                        "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved":
+                        "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "requires": {
+                        "is-descriptor": "0.1.6"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "requires": {
+                        "is-extendable": "0.1.1"
+                    }
+                }
+            }
+        },
+        "expand-range": {
+            "version": "1.8.2",
+            "resolved":
+                "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+            "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+            "dev": true,
+            "requires": {
+                "fill-range": "2.2.4"
+            },
+            "dependencies": {
+                "fill-range": {
+                    "version": "2.2.4",
+                    "resolved":
+                        "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+                    "integrity":
+                        "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "2.1.0",
+                        "isobject": "2.1.0",
+                        "randomatic": "3.0.0",
+                        "repeat-element": "1.1.2",
+                        "repeat-string": "1.6.1"
+                    }
+                },
+                "is-number": {
+                    "version": "2.1.0",
+                    "resolved":
+                        "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+                    "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    }
+                },
+                "isobject": {
+                    "version": "2.1.0",
+                    "resolved":
+                        "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                    "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                    "dev": true,
+                    "requires": {
+                        "isarray": "1.0.0"
+                    }
+                },
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved":
+                        "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
+        "expand-tilde": {
+            "version": "1.2.2",
+            "resolved":
+                "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+            "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
+            "dev": true,
+            "requires": {
+                "os-homedir": "1.0.2"
+            }
+        },
+        "expect": {
+            "version": "22.4.3",
+            "resolved": "https://registry.npmjs.org/expect/-/expect-22.4.3.tgz",
+            "integrity":
+                "sha512-XcNXEPehqn8b/jm8FYotdX0YrXn36qp4HWlrVT4ktwQas1l1LPxiVWncYnnL2eyMtKAmVIaG0XAp0QlrqJaxaA==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "3.2.1",
+                "jest-diff": "22.4.3",
+                "jest-get-type": "22.4.3",
+                "jest-matcher-utils": "22.4.3",
+                "jest-message-util": "22.4.3",
+                "jest-regex-util": "22.4.3"
+            }
+        },
+        "extend": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+            "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+            "dev": true
+        },
+        "extend-shallow": {
+            "version": "3.0.2",
+            "resolved":
+                "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+            "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+            "requires": {
+                "assign-symbols": "1.0.0",
+                "is-extendable": "1.0.1"
+            },
+            "dependencies": {
+                "is-extendable": {
+                    "version": "1.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity":
+                        "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "requires": {
+                        "is-plain-object": "2.0.4"
+                    }
+                }
+            }
         },
         "external-editor": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
-          "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
-          "dev": true,
-          "requires": {
-            "extend": "3.0.1",
-            "spawn-sync": "1.0.15",
-            "tmp": "0.0.29"
-          }
+            "version": "2.2.0",
+            "resolved":
+                "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+            "integrity":
+                "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+            "requires": {
+                "chardet": "0.4.2",
+                "iconv-lite": "0.4.23",
+                "tmp": "0.0.33"
+            }
+        },
+        "extglob": {
+            "version": "2.0.4",
+            "resolved":
+                "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+            "integrity":
+                "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+            "requires": {
+                "array-unique": "0.3.2",
+                "define-property": "1.0.0",
+                "expand-brackets": "2.1.4",
+                "extend-shallow": "2.0.1",
+                "fragment-cache": "0.2.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "requires": {
+                        "is-descriptor": "1.0.2"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "requires": {
+                        "is-extendable": "0.1.1"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity":
+                        "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "requires": {
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity":
+                        "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "requires": {
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved":
+                        "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity":
+                        "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "requires": {
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
+                    }
+                }
+            }
+        },
+        "extsprintf": {
+            "version": "1.3.0",
+            "resolved":
+                "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+            "dev": true
+        },
+        "faker": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/faker/-/faker-4.1.0.tgz",
+            "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8=",
+            "dev": true
+        },
+        "fast-deep-equal": {
+            "version": "1.1.0",
+            "resolved":
+                "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+            "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+            "dev": true
+        },
+        "fast-diff": {
+            "version": "1.1.2",
+            "resolved":
+                "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+            "integrity":
+                "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
+            "dev": true
+        },
+        "fast-glob": {
+            "version": "2.2.2",
+            "resolved":
+                "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.2.tgz",
+            "integrity":
+                "sha512-TR6zxCKftDQnUAPvkrCWdBgDq/gbqx8A3ApnBrR5rMvpp6+KMJI0Igw7fkWPgeVK0uhRXTXdvO3O+YP0CaUX2g==",
+            "requires": {
+                "@mrmlnc/readdir-enhanced": "2.2.1",
+                "@nodelib/fs.stat": "1.0.2",
+                "glob-parent": "3.1.0",
+                "is-glob": "4.0.0",
+                "merge2": "1.2.2",
+                "micromatch": "3.1.10"
+            }
+        },
+        "fast-json-stable-stringify": {
+            "version": "2.0.0",
+            "resolved":
+                "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+            "dev": true
+        },
+        "fast-levenshtein": {
+            "version": "2.0.6",
+            "resolved":
+                "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+            "dev": true
+        },
+        "fb-watchman": {
+            "version": "2.0.0",
+            "resolved":
+                "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
+            "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+            "dev": true,
+            "requires": {
+                "bser": "2.0.0"
+            }
         },
         "figures": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-          "dev": true,
-          "requires": {
-            "escape-string-regexp": "1.0.5",
-            "object-assign": "4.1.1"
-          }
+            "version": "2.0.0",
+            "resolved":
+                "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+            "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+            "requires": {
+                "escape-string-regexp": "1.0.5"
+            }
+        },
+        "file-entry-cache": {
+            "version": "2.0.0",
+            "resolved":
+                "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+            "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+            "dev": true,
+            "requires": {
+                "flat-cache": "1.3.0",
+                "object-assign": "4.1.1"
+            }
+        },
+        "filename-regex": {
+            "version": "2.0.1",
+            "resolved":
+                "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+            "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+            "dev": true
+        },
+        "fileset": {
+            "version": "2.0.3",
+            "resolved":
+                "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
+            "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
+            "dev": true,
+            "requires": {
+                "glob": "7.1.2",
+                "minimatch": "3.0.4"
+            }
+        },
+        "fill-range": {
+            "version": "4.0.0",
+            "resolved":
+                "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+            "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+            "requires": {
+                "extend-shallow": "2.0.1",
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1",
+                "to-regex-range": "2.1.1"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "requires": {
+                        "is-extendable": "0.1.1"
+                    }
+                }
+            }
+        },
+        "find-node-modules": {
+            "version": "1.0.4",
+            "resolved":
+                "https://registry.npmjs.org/find-node-modules/-/find-node-modules-1.0.4.tgz",
+            "integrity": "sha1-tt6zzMtpnIcDdne87eLF9YYrJVA=",
+            "dev": true,
+            "requires": {
+                "findup-sync": "0.4.2",
+                "merge": "1.2.0"
+            }
+        },
+        "find-parent-dir": {
+            "version": "0.3.0",
+            "resolved":
+                "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
+            "integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
+            "dev": true
+        },
+        "find-root": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/find-root/-/find-root-1.0.0.tgz",
+            "integrity": "sha1-li/yEaqyXGUg/u641ih/j26VgHo=",
+            "dev": true
+        },
+        "find-up": {
+            "version": "2.1.0",
+            "resolved":
+                "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+            "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+            "requires": {
+                "locate-path": "2.0.0"
+            }
+        },
+        "findup-sync": {
+            "version": "0.4.2",
+            "resolved":
+                "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.2.tgz",
+            "integrity": "sha1-qBF9D3MST1pFRoOVef5S1xKfteU=",
+            "dev": true,
+            "requires": {
+                "detect-file": "0.1.0",
+                "is-glob": "2.0.1",
+                "micromatch": "2.3.11",
+                "resolve-dir": "0.1.1"
+            },
+            "dependencies": {
+                "arr-diff": {
+                    "version": "2.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                    "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+                    "dev": true,
+                    "requires": {
+                        "arr-flatten": "1.1.0"
+                    }
+                },
+                "array-unique": {
+                    "version": "0.2.1",
+                    "resolved":
+                        "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+                    "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+                    "dev": true
+                },
+                "braces": {
+                    "version": "1.8.5",
+                    "resolved":
+                        "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+                    "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+                    "dev": true,
+                    "requires": {
+                        "expand-range": "1.8.2",
+                        "preserve": "0.2.0",
+                        "repeat-element": "1.1.2"
+                    }
+                },
+                "expand-brackets": {
+                    "version": "0.1.5",
+                    "resolved":
+                        "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+                    "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+                    "dev": true,
+                    "requires": {
+                        "is-posix-bracket": "0.1.1"
+                    }
+                },
+                "extglob": {
+                    "version": "0.3.2",
+                    "resolved":
+                        "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+                    "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "1.0.0"
+                    }
+                },
+                "is-extglob": {
+                    "version": "1.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                    "dev": true
+                },
+                "is-glob": {
+                    "version": "2.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "1.0.0"
+                    }
+                },
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved":
+                        "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                },
+                "micromatch": {
+                    "version": "2.3.11",
+                    "resolved":
+                        "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+                    "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+                    "dev": true,
+                    "requires": {
+                        "arr-diff": "2.0.0",
+                        "array-unique": "0.2.1",
+                        "braces": "1.8.5",
+                        "expand-brackets": "0.1.5",
+                        "extglob": "0.3.2",
+                        "filename-regex": "2.0.1",
+                        "is-extglob": "1.0.0",
+                        "is-glob": "2.0.1",
+                        "kind-of": "3.2.2",
+                        "normalize-path": "2.1.1",
+                        "object.omit": "2.0.1",
+                        "parse-glob": "3.0.4",
+                        "regex-cache": "0.4.4"
+                    }
+                }
+            }
+        },
+        "first-chunk-stream": {
+            "version": "2.0.0",
+            "resolved":
+                "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
+            "integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
+            "requires": {
+                "readable-stream": "2.3.6"
+            }
+        },
+        "flat-cache": {
+            "version": "1.3.0",
+            "resolved":
+                "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+            "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+            "dev": true,
+            "requires": {
+                "circular-json": "0.3.3",
+                "del": "2.2.2",
+                "graceful-fs": "4.1.11",
+                "write": "0.2.1"
+            }
+        },
+        "for-in": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+        },
+        "for-own": {
+            "version": "0.1.5",
+            "resolved":
+                "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+            "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+            "dev": true,
+            "requires": {
+                "for-in": "1.0.2"
+            }
+        },
+        "foreach": {
+            "version": "2.0.5",
+            "resolved":
+                "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+            "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+            "dev": true
+        },
+        "forever-agent": {
+            "version": "0.6.1",
+            "resolved":
+                "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+            "dev": true
+        },
+        "form-data": {
+            "version": "2.3.2",
+            "resolved":
+                "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+            "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+            "dev": true,
+            "requires": {
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.6",
+                "mime-types": "2.1.18"
+            }
+        },
+        "fragment-cache": {
+            "version": "0.2.1",
+            "resolved":
+                "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+            "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+            "requires": {
+                "map-cache": "0.2.2"
+            }
+        },
+        "from2": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+            "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6"
+            }
+        },
+        "fs-exists-sync": {
+            "version": "0.1.0",
+            "resolved":
+                "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+            "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
+            "dev": true
+        },
+        "fs-extra": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+            "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "4.1.11",
+                "jsonfile": "2.4.0",
+                "klaw": "1.3.1"
+            }
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+        },
+        "fsevents": {
+            "version": "1.2.4",
+            "resolved":
+                "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+            "integrity":
+                "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "nan": "2.10.0",
+                "node-pre-gyp": "0.10.0"
+            },
+            "dependencies": {
+                "abbrev": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "aproba": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "are-we-there-yet": {
+                    "version": "1.1.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "delegates": "1.0.0",
+                        "readable-stream": "2.3.6"
+                    }
+                },
+                "balanced-match": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "brace-expansion": {
+                    "version": "1.1.11",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "1.0.0",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "chownr": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "code-point-at": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "console-control-strings": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "core-util-is": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "debug": {
+                    "version": "2.6.9",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "deep-extend": {
+                    "version": "0.5.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "delegates": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "detect-libc": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "fs-minipass": {
+                    "version": "1.2.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "minipass": "2.2.4"
+                    }
+                },
+                "fs.realpath": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "gauge": {
+                    "version": "2.7.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "aproba": "1.2.0",
+                        "console-control-strings": "1.1.0",
+                        "has-unicode": "2.0.1",
+                        "object-assign": "4.1.1",
+                        "signal-exit": "3.0.2",
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1",
+                        "wide-align": "1.1.2"
+                    }
+                },
+                "glob": {
+                    "version": "7.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
+                },
+                "has-unicode": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "iconv-lite": {
+                    "version": "0.4.21",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "safer-buffer": "2.1.2"
+                    }
+                },
+                "ignore-walk": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "minimatch": "3.0.4"
+                    }
+                },
+                "inflight": {
+                    "version": "1.0.6",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "ini": {
+                    "version": "1.3.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "number-is-nan": "1.0.1"
+                    }
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "1.1.11"
+                    }
+                },
+                "minimist": {
+                    "version": "0.0.8",
+                    "bundled": true,
+                    "dev": true
+                },
+                "minipass": {
+                    "version": "2.2.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.1.1",
+                        "yallist": "3.0.2"
+                    }
+                },
+                "minizlib": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "minipass": "2.2.4"
+                    }
+                },
+                "mkdirp": {
+                    "version": "0.5.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "minimist": "0.0.8"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "needle": {
+                    "version": "2.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "debug": "2.6.9",
+                        "iconv-lite": "0.4.21",
+                        "sax": "1.2.4"
+                    }
+                },
+                "node-pre-gyp": {
+                    "version": "0.10.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "detect-libc": "1.0.3",
+                        "mkdirp": "0.5.1",
+                        "needle": "2.2.0",
+                        "nopt": "4.0.1",
+                        "npm-packlist": "1.1.10",
+                        "npmlog": "4.1.2",
+                        "rc": "1.2.7",
+                        "rimraf": "2.6.2",
+                        "semver": "5.5.0",
+                        "tar": "4.4.1"
+                    }
+                },
+                "nopt": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "abbrev": "1.1.1",
+                        "osenv": "0.1.5"
+                    }
+                },
+                "npm-bundled": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "npm-packlist": {
+                    "version": "1.1.10",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "ignore-walk": "3.0.1",
+                        "npm-bundled": "1.0.3"
+                    }
+                },
+                "npmlog": {
+                    "version": "4.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "are-we-there-yet": "1.1.4",
+                        "console-control-strings": "1.1.0",
+                        "gauge": "2.7.4",
+                        "set-blocking": "2.0.0"
+                    }
+                },
+                "number-is-nan": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "object-assign": {
+                    "version": "4.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "once": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "wrappy": "1.0.2"
+                    }
+                },
+                "os-homedir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "os-tmpdir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "osenv": {
+                    "version": "0.1.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "os-homedir": "1.0.2",
+                        "os-tmpdir": "1.0.2"
+                    }
+                },
+                "path-is-absolute": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "process-nextick-args": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "rc": {
+                    "version": "1.2.7",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "deep-extend": "0.5.1",
+                        "ini": "1.3.5",
+                        "minimist": "1.2.0",
+                        "strip-json-comments": "2.0.1"
+                    },
+                    "dependencies": {
+                        "minimist": {
+                            "version": "1.2.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "rimraf": {
+                    "version": "2.6.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "glob": "7.1.2"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "safer-buffer": {
+                    "version": "2.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "sax": {
+                    "version": "1.2.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "semver": {
+                    "version": "5.5.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "set-blocking": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "signal-exit": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "safe-buffer": "5.1.1"
+                    }
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
+                },
+                "strip-json-comments": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "tar": {
+                    "version": "4.4.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "chownr": "1.0.1",
+                        "fs-minipass": "1.2.5",
+                        "minipass": "2.2.4",
+                        "minizlib": "1.1.0",
+                        "mkdirp": "0.5.1",
+                        "safe-buffer": "5.1.1",
+                        "yallist": "3.0.2"
+                    }
+                },
+                "util-deprecate": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "wide-align": {
+                    "version": "1.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "string-width": "1.0.2"
+                    }
+                },
+                "wrappy": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "yallist": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "dev": true
+                }
+            }
+        },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved":
+                "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity":
+                "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
+        },
+        "functional-red-black-tree": {
+            "version": "1.0.1",
+            "resolved":
+                "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+            "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+            "dev": true
+        },
+        "get-caller-file": {
+            "version": "1.0.2",
+            "resolved":
+                "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+            "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+            "dev": true
+        },
+        "get-own-enumerable-property-symbols": {
+            "version": "2.0.1",
+            "resolved":
+                "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz",
+            "integrity":
+                "sha512-TtY/sbOemiMKPRUDDanGCSgBYe7Mf0vbRsWnBZ+9yghpZ1MvcpSpuZFjHdEeY/LZjZy0vdLjS77L6HosisFiug==",
+            "dev": true
+        },
+        "get-stdin": {
+            "version": "4.0.1",
+            "resolved":
+                "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+            "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+        },
+        "get-stream": {
+            "version": "3.0.0",
+            "resolved":
+                "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+            "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+        },
+        "get-value": {
+            "version": "2.0.6",
+            "resolved":
+                "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+            "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+        },
+        "getpass": {
+            "version": "0.1.7",
+            "resolved":
+                "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0"
+            }
         },
         "gh-got": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/gh-got/-/gh-got-5.0.0.tgz",
-          "integrity": "sha1-7pW+NxBv2HSKlvjR20uuqJ4b+oo=",
-          "dev": true,
-          "requires": {
-            "got": "6.7.1",
-            "is-plain-obj": "1.1.0"
-          }
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/gh-got/-/gh-got-6.0.0.tgz",
+            "integrity":
+                "sha512-F/mS+fsWQMo1zfgG9MD8KWvTWPPzzhuVwY++fhQ5Ggd+0P+CAMHtzMZhNxG+TqGfHDChJKsbh6otfMGqO2AKBw==",
+            "requires": {
+                "got": "7.1.0",
+                "is-plain-obj": "1.1.0"
+            }
+        },
+        "git-log-parser": {
+            "version": "1.2.0",
+            "resolved":
+                "https://registry.npmjs.org/git-log-parser/-/git-log-parser-1.2.0.tgz",
+            "integrity": "sha1-LmpMGxP8AAKCB7p5WnrDFme5/Uo=",
+            "dev": true,
+            "requires": {
+                "argv-formatter": "1.0.0",
+                "spawn-error-forwarder": "1.0.0",
+                "split2": "1.0.0",
+                "stream-combiner2": "1.1.1",
+                "through2": "2.0.3",
+                "traverse": "0.6.6"
+            },
+            "dependencies": {
+                "split2": {
+                    "version": "1.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/split2/-/split2-1.0.0.tgz",
+                    "integrity": "sha1-UuLiIdiMdfmnP5BVbiY/+WdysxQ=",
+                    "dev": true,
+                    "requires": {
+                        "through2": "2.0.3"
+                    }
+                }
+            }
+        },
+        "git-up": {
+            "version": "2.0.10",
+            "resolved": "https://registry.npmjs.org/git-up/-/git-up-2.0.10.tgz",
+            "integrity":
+                "sha512-2v4UN3qV2RGypD9QpmUjpk+4+RlYpW8GFuiZqQnKmvei08HsFPd0RfbDvEhnE4wBvnYs8ORVtYpOFuuCEmBVBw==",
+            "dev": true,
+            "requires": {
+                "is-ssh": "1.3.0",
+                "parse-url": "1.3.11"
+            }
+        },
+        "git-url-parse": {
+            "version": "9.0.0",
+            "resolved":
+                "https://registry.npmjs.org/git-url-parse/-/git-url-parse-9.0.0.tgz",
+            "integrity":
+                "sha512-zks1jS4ocMA/9WUx3C0nGIj/wBQjjIuktQ4KqKTyStMdEtnnFbZ4ZVKCvNeHwKh1COk/8sZaVTyvYj3paHI9Fg==",
+            "dev": true,
+            "requires": {
+                "git-up": "2.0.10",
+                "parse-domain": "2.0.0"
+            }
         },
         "github-username": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/github-username/-/github-username-3.0.0.tgz",
-          "integrity": "sha1-CnciGbMTB0NCnyRW0L3T21Xc57E=",
-          "dev": true,
-          "requires": {
-            "gh-got": "5.0.0"
-          }
+            "version": "4.1.0",
+            "resolved":
+                "https://registry.npmjs.org/github-username/-/github-username-4.1.0.tgz",
+            "integrity": "sha1-y+KABBiDIG2kISrp5LXxacML9Bc=",
+            "requires": {
+                "gh-got": "6.0.0"
+            }
         },
-        "globby": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-4.1.0.tgz",
-          "integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
-          "dev": true,
-          "requires": {
-            "array-union": "1.0.2",
-            "arrify": "1.0.1",
-            "glob": "6.0.4",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          },
-          "dependencies": {
-            "glob": {
-              "version": "6.0.4",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-              "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-              "dev": true,
-              "requires": {
+        "glob": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+            "integrity":
+                "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+            "requires": {
+                "fs.realpath": "1.0.0",
                 "inflight": "1.0.6",
                 "inherits": "2.0.3",
                 "minimatch": "3.0.4",
                 "once": "1.4.0",
                 "path-is-absolute": "1.0.1"
-              }
             }
-          }
+        },
+        "glob-base": {
+            "version": "0.3.0",
+            "resolved":
+                "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+            "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+            "dev": true,
+            "requires": {
+                "glob-parent": "2.0.0",
+                "is-glob": "2.0.1"
+            },
+            "dependencies": {
+                "glob-parent": {
+                    "version": "2.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+                    "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+                    "dev": true,
+                    "requires": {
+                        "is-glob": "2.0.1"
+                    }
+                },
+                "is-extglob": {
+                    "version": "1.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                    "dev": true
+                },
+                "is-glob": {
+                    "version": "2.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "1.0.0"
+                    }
+                }
+            }
+        },
+        "glob-parent": {
+            "version": "3.1.0",
+            "resolved":
+                "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+            "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+            "requires": {
+                "is-glob": "3.1.0",
+                "path-dirname": "1.0.2"
+            },
+            "dependencies": {
+                "is-glob": {
+                    "version": "3.1.0",
+                    "resolved":
+                        "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+                    "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                    "requires": {
+                        "is-extglob": "2.1.1"
+                    }
+                }
+            }
+        },
+        "glob-to-regexp": {
+            "version": "0.3.0",
+            "resolved":
+                "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+            "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
+        },
+        "global-modules": {
+            "version": "0.2.3",
+            "resolved":
+                "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
+            "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
+            "dev": true,
+            "requires": {
+                "global-prefix": "0.1.5",
+                "is-windows": "0.2.0"
+            },
+            "dependencies": {
+                "is-windows": {
+                    "version": "0.2.0",
+                    "resolved":
+                        "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+                    "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
+                    "dev": true
+                }
+            }
+        },
+        "global-prefix": {
+            "version": "0.1.5",
+            "resolved":
+                "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+            "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
+            "dev": true,
+            "requires": {
+                "homedir-polyfill": "1.0.1",
+                "ini": "1.3.5",
+                "is-windows": "0.2.0",
+                "which": "1.3.0"
+            },
+            "dependencies": {
+                "is-windows": {
+                    "version": "0.2.0",
+                    "resolved":
+                        "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+                    "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
+                    "dev": true
+                }
+            }
+        },
+        "globals": {
+            "version": "11.5.0",
+            "resolved":
+                "https://registry.npmjs.org/globals/-/globals-11.5.0.tgz",
+            "integrity":
+                "sha512-hYyf+kI8dm3nORsiiXUQigOU62hDLfJ9G01uyGMxhc6BKsircrUhC4uJPQPUSuq2GrTmiiEt7ewxlMdBewfmKQ==",
+            "dev": true
+        },
+        "globby": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
+            "integrity":
+                "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
+            "requires": {
+                "array-union": "1.0.2",
+                "dir-glob": "2.0.0",
+                "fast-glob": "2.2.2",
+                "glob": "7.1.2",
+                "ignore": "3.3.8",
+                "pify": "3.0.0",
+                "slash": "1.0.0"
+            }
         },
         "got": {
-          "version": "6.7.1",
-          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
-          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
-          "dev": true,
-          "requires": {
-            "create-error-class": "3.0.2",
-            "duplexer3": "0.1.4",
-            "get-stream": "3.0.0",
-            "is-redirect": "1.0.0",
-            "is-retry-allowed": "1.1.0",
-            "is-stream": "1.1.0",
-            "lowercase-keys": "1.0.1",
-            "safe-buffer": "5.1.1",
-            "timed-out": "4.0.1",
-            "unzip-response": "2.0.1",
-            "url-parse-lax": "1.0.0"
-          }
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
+            "integrity":
+                "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+            "requires": {
+                "decompress-response": "3.3.0",
+                "duplexer3": "0.1.4",
+                "get-stream": "3.0.0",
+                "is-plain-obj": "1.1.0",
+                "is-retry-allowed": "1.1.0",
+                "is-stream": "1.1.0",
+                "isurl": "1.0.0",
+                "lowercase-keys": "1.0.1",
+                "p-cancelable": "0.3.0",
+                "p-timeout": "1.2.1",
+                "safe-buffer": "5.1.2",
+                "timed-out": "4.0.1",
+                "url-parse-lax": "1.0.0",
+                "url-to-options": "1.0.1"
+            }
+        },
+        "graceful-fs": {
+            "version": "4.1.11",
+            "resolved":
+                "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+        },
+        "grouped-queue": {
+            "version": "0.3.3",
+            "resolved":
+                "https://registry.npmjs.org/grouped-queue/-/grouped-queue-0.3.3.tgz",
+            "integrity": "sha1-wWfSpTGcWg4JZO9qJbfC34mWyFw=",
+            "requires": {
+                "lodash": "4.17.10"
+            }
+        },
+        "growly": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+            "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+            "dev": true
+        },
+        "handlebars": {
+            "version": "4.0.11",
+            "resolved":
+                "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+            "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+            "dev": true,
+            "requires": {
+                "async": "1.5.2",
+                "optimist": "0.6.1",
+                "source-map": "0.4.4",
+                "uglify-js": "2.8.29"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "1.5.2",
+                    "resolved":
+                        "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                    "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.4.4",
+                    "resolved":
+                        "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                    "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+                    "dev": true,
+                    "requires": {
+                        "amdefine": "1.0.1"
+                    }
+                }
+            }
+        },
+        "har-schema": {
+            "version": "2.0.0",
+            "resolved":
+                "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+            "dev": true
+        },
+        "har-validator": {
+            "version": "5.0.3",
+            "resolved":
+                "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+            "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+            "dev": true,
+            "requires": {
+                "ajv": "5.5.2",
+                "har-schema": "2.0.0"
+            }
+        },
+        "has": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+            "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+            "dev": true,
+            "requires": {
+                "function-bind": "1.1.1"
+            }
+        },
+        "has-ansi": {
+            "version": "2.0.0",
+            "resolved":
+                "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+            "requires": {
+                "ansi-regex": "2.1.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved":
+                        "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+                }
+            }
+        },
+        "has-flag": {
+            "version": "3.0.0",
+            "resolved":
+                "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "has-symbol-support-x": {
+            "version": "1.4.2",
+            "resolved":
+                "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
+            "integrity":
+                "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
+        },
+        "has-to-string-tag-x": {
+            "version": "1.4.1",
+            "resolved":
+                "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
+            "integrity":
+                "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+            "requires": {
+                "has-symbol-support-x": "1.4.2"
+            }
+        },
+        "has-value": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+            "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+            "requires": {
+                "get-value": "2.0.6",
+                "has-values": "1.0.0",
+                "isobject": "3.0.1"
+            }
+        },
+        "has-values": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+            "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+            "requires": {
+                "is-number": "3.0.0",
+                "kind-of": "4.0.0"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "4.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+                    "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
+        "hawk": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+            "integrity":
+                "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+            "dev": true,
+            "requires": {
+                "boom": "4.3.1",
+                "cryptiles": "3.1.2",
+                "hoek": "4.2.1",
+                "sntp": "2.1.0"
+            }
+        },
+        "hoek": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+            "integrity":
+                "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
+            "dev": true
+        },
+        "home-or-tmp": {
+            "version": "2.0.0",
+            "resolved":
+                "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+            "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+            "dev": true,
+            "requires": {
+                "os-homedir": "1.0.2",
+                "os-tmpdir": "1.0.2"
+            }
+        },
+        "homedir-polyfill": {
+            "version": "1.0.1",
+            "resolved":
+                "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+            "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+            "dev": true,
+            "requires": {
+                "parse-passwd": "1.0.0"
+            }
+        },
+        "hook-std": {
+            "version": "0.4.0",
+            "resolved":
+                "https://registry.npmjs.org/hook-std/-/hook-std-0.4.0.tgz",
+            "integrity": "sha1-+osvhNNYdjE3y30X4zCLKHFL0XQ=",
+            "dev": true
+        },
+        "hosted-git-info": {
+            "version": "2.6.0",
+            "resolved":
+                "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
+            "integrity":
+                "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
+        },
+        "html-encoding-sniffer": {
+            "version": "1.0.2",
+            "resolved":
+                "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+            "integrity":
+                "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+            "dev": true,
+            "requires": {
+                "whatwg-encoding": "1.0.3"
+            }
+        },
+        "http-proxy-agent": {
+            "version": "2.1.0",
+            "resolved":
+                "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+            "integrity":
+                "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+            "dev": true,
+            "requires": {
+                "agent-base": "4.2.0",
+                "debug": "3.1.0"
+            }
+        },
+        "http-signature": {
+            "version": "1.2.0",
+            "resolved":
+                "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.14.1"
+            }
+        },
+        "https-proxy-agent": {
+            "version": "2.2.1",
+            "resolved":
+                "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+            "integrity":
+                "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+            "dev": true,
+            "requires": {
+                "agent-base": "4.2.0",
+                "debug": "3.1.0"
+            }
+        },
+        "husky": {
+            "version": "0.14.3",
+            "resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
+            "integrity":
+                "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
+            "dev": true,
+            "requires": {
+                "is-ci": "1.1.0",
+                "normalize-path": "1.0.0",
+                "strip-indent": "2.0.0"
+            },
+            "dependencies": {
+                "normalize-path": {
+                    "version": "1.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
+                    "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
+                    "dev": true
+                }
+            }
+        },
+        "iconv-lite": {
+            "version": "0.4.23",
+            "resolved":
+                "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+            "integrity":
+                "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+            "requires": {
+                "safer-buffer": "2.1.2"
+            }
+        },
+        "ignore": {
+            "version": "3.3.8",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz",
+            "integrity":
+                "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg=="
+        },
+        "import-from": {
+            "version": "2.1.0",
+            "resolved":
+                "https://registry.npmjs.org/import-from/-/import-from-2.1.0.tgz",
+            "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
+            "dev": true,
+            "requires": {
+                "resolve-from": "3.0.0"
+            },
+            "dependencies": {
+                "resolve-from": {
+                    "version": "3.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+                    "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+                    "dev": true
+                }
+            }
+        },
+        "import-local": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
+            "integrity":
+                "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+            "dev": true,
+            "requires": {
+                "pkg-dir": "2.0.0",
+                "resolve-cwd": "2.0.0"
+            }
+        },
+        "imurmurhash": {
+            "version": "0.1.4",
+            "resolved":
+                "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+            "dev": true
+        },
+        "indent-string": {
+            "version": "2.1.0",
+            "resolved":
+                "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+            "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+            "dev": true,
+            "requires": {
+                "repeating": "2.0.1"
+            }
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved":
+                "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "requires": {
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
+            }
+        },
+        "inherits": {
+            "version": "2.0.3",
+            "resolved":
+                "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        },
+        "ini": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+            "integrity":
+                "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+            "dev": true
+        },
+        "inquirer": {
+            "version": "5.2.0",
+            "resolved":
+                "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
+            "integrity":
+                "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
+            "requires": {
+                "ansi-escapes": "3.1.0",
+                "chalk": "2.4.1",
+                "cli-cursor": "2.1.0",
+                "cli-width": "2.2.0",
+                "external-editor": "2.2.0",
+                "figures": "2.0.0",
+                "lodash": "4.17.10",
+                "mute-stream": "0.0.7",
+                "run-async": "2.3.0",
+                "rxjs": "5.5.10",
+                "string-width": "2.1.1",
+                "strip-ansi": "4.0.0",
+                "through": "2.3.8"
+            }
+        },
+        "interpret": {
+            "version": "1.1.0",
+            "resolved":
+                "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+            "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
+        },
+        "into-stream": {
+            "version": "3.1.0",
+            "resolved":
+                "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+            "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
+            "dev": true,
+            "requires": {
+                "from2": "2.3.0",
+                "p-is-promise": "1.1.0"
+            }
+        },
+        "invariant": {
+            "version": "2.2.4",
+            "resolved":
+                "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+            "integrity":
+                "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+            "dev": true,
+            "requires": {
+                "loose-envify": "1.3.1"
+            }
+        },
+        "invert-kv": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+            "dev": true
+        },
+        "is-accessor-descriptor": {
+            "version": "0.1.6",
+            "resolved":
+                "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+            "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+            "requires": {
+                "kind-of": "3.2.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved":
+                        "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
+        "is-arrayish": {
+            "version": "0.2.1",
+            "resolved":
+                "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+        },
+        "is-buffer": {
+            "version": "1.1.6",
+            "resolved":
+                "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+            "integrity":
+                "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+        },
+        "is-builtin-module": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+            "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+            "requires": {
+                "builtin-modules": "1.1.1"
+            }
+        },
+        "is-callable": {
+            "version": "1.1.3",
+            "resolved":
+                "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+            "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+            "dev": true
+        },
+        "is-ci": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
+            "integrity":
+                "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+            "dev": true,
+            "requires": {
+                "ci-info": "1.1.3"
+            }
+        },
+        "is-data-descriptor": {
+            "version": "0.1.4",
+            "resolved":
+                "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+            "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+            "requires": {
+                "kind-of": "3.2.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved":
+                        "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
+        "is-date-object": {
+            "version": "1.0.1",
+            "resolved":
+                "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+            "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+            "dev": true
+        },
+        "is-descriptor": {
+            "version": "0.1.6",
+            "resolved":
+                "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+            "integrity":
+                "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+            "requires": {
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved":
+                        "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity":
+                        "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+                }
+            }
+        },
+        "is-directory": {
+            "version": "0.3.1",
+            "resolved":
+                "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+            "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+            "dev": true
+        },
+        "is-dotfile": {
+            "version": "1.0.3",
+            "resolved":
+                "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+            "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+            "dev": true
+        },
+        "is-equal-shallow": {
+            "version": "0.1.3",
+            "resolved":
+                "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+            "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+            "dev": true,
+            "requires": {
+                "is-primitive": "2.0.0"
+            }
+        },
+        "is-extendable": {
+            "version": "0.1.1",
+            "resolved":
+                "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+        },
+        "is-extglob": {
+            "version": "2.1.1",
+            "resolved":
+                "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+        },
+        "is-finite": {
+            "version": "1.0.2",
+            "resolved":
+                "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+            "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+            "dev": true,
+            "requires": {
+                "number-is-nan": "1.0.1"
+            }
         },
         "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
+            "version": "2.0.0",
+            "resolved":
+                "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
-        "load-json-file": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "strip-bom": "3.0.0"
-          }
+        "is-generator-fn": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
+            "integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go=",
+            "dev": true
         },
-        "log-symbols": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
-          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-          "dev": true,
-          "requires": {
-            "chalk": "1.1.3"
-          }
+        "is-glob": {
+            "version": "4.0.0",
+            "resolved":
+                "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+            "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+            "requires": {
+                "is-extglob": "2.1.1"
+            }
         },
-        "mute-stream": {
-          "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
-          "integrity": "sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s=",
-          "dev": true
+        "is-number": {
+            "version": "3.0.0",
+            "resolved":
+                "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+            "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+            "requires": {
+                "kind-of": "3.2.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved":
+                        "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
         },
-        "onetime": {
-          "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-          "dev": true
+        "is-obj": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+            "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+            "dev": true
         },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "1.3.1"
-          }
+        "is-object": {
+            "version": "1.0.1",
+            "resolved":
+                "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+            "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
         },
-        "path-type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-          "dev": true,
-          "requires": {
-            "pify": "2.3.0"
-          }
+        "is-observable": {
+            "version": "0.2.0",
+            "resolved":
+                "https://registry.npmjs.org/is-observable/-/is-observable-0.2.0.tgz",
+            "integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
+            "dev": true,
+            "requires": {
+                "symbol-observable": "0.2.4"
+            },
+            "dependencies": {
+                "symbol-observable": {
+                    "version": "0.2.4",
+                    "resolved":
+                        "https://registry.npmjs.org/symbol-observable/-/symbol-observable-0.2.4.tgz",
+                    "integrity": "sha1-lag9smGG1q9+ehjb2XYKL4bQj0A=",
+                    "dev": true
+                }
+            }
         },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
+        "is-odd": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
+            "integrity":
+                "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
+            "requires": {
+                "is-number": "4.0.0"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "4.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+                    "integrity":
+                        "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+                }
+            }
         },
-        "read-pkg": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "2.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "2.0.0"
-          }
+        "is-path-cwd": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+            "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+            "dev": true
         },
-        "read-pkg-up": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "dev": true,
-          "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "2.0.0"
-          }
+        "is-path-in-cwd": {
+            "version": "1.0.1",
+            "resolved":
+                "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+            "integrity":
+                "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+            "dev": true,
+            "requires": {
+                "is-path-inside": "1.0.1"
+            }
         },
-        "restore-cursor": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-          "dev": true,
-          "requires": {
-            "exit-hook": "1.1.1",
-            "onetime": "1.1.0"
-          }
+        "is-path-inside": {
+            "version": "1.0.1",
+            "resolved":
+                "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+            "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+            "dev": true,
+            "requires": {
+                "path-is-inside": "1.0.2"
+            }
         },
-        "shelljs": {
-          "version": "0.7.8",
-          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
-          "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
-          "dev": true,
-          "requires": {
-            "glob": "7.1.2",
-            "interpret": "1.1.0",
-            "rechoir": "0.6.2"
-          }
+        "is-plain-obj": {
+            "version": "1.1.0",
+            "resolved":
+                "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+            "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
         },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
+        "is-plain-object": {
+            "version": "2.0.4",
+            "resolved":
+                "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+            "integrity":
+                "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+            "requires": {
+                "isobject": "3.0.1"
+            }
         },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
+        "is-posix-bracket": {
+            "version": "0.1.1",
+            "resolved":
+                "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+            "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+            "dev": true
         },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
+        "is-primitive": {
+            "version": "2.0.0",
+            "resolved":
+                "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+            "dev": true
         },
-        "tmp": {
-          "version": "0.0.29",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
-          "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "1.0.2"
-          }
+        "is-promise": {
+            "version": "2.1.0",
+            "resolved":
+                "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+            "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
         },
-        "untildify": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
-          "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
-          "dev": true,
-          "requires": {
-            "os-homedir": "1.0.2"
-          }
+        "is-regex": {
+            "version": "1.0.4",
+            "resolved":
+                "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+            "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+            "dev": true,
+            "requires": {
+                "has": "1.0.1"
+            }
         },
-        "yeoman-generator": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-1.1.1.tgz",
-          "integrity": "sha1-QMK09s374F4ZUv3XKTPw2JJdvfU=",
-          "dev": true,
-          "requires": {
-            "async": "2.6.0",
-            "chalk": "1.1.3",
-            "class-extend": "0.1.2",
-            "cli-table": "0.3.1",
-            "cross-spawn": "5.1.0",
-            "dargs": "5.1.0",
-            "dateformat": "2.2.0",
-            "debug": "2.6.9",
-            "detect-conflict": "1.0.1",
-            "error": "7.0.2",
-            "find-up": "2.1.0",
-            "github-username": "3.0.0",
-            "glob": "7.1.2",
-            "istextorbinary": "2.2.1",
-            "lodash": "4.17.5",
-            "mem-fs-editor": "3.0.2",
-            "minimist": "1.2.0",
-            "mkdirp": "0.5.1",
-            "path-exists": "3.0.0",
-            "path-is-absolute": "1.0.1",
-            "pretty-bytes": "4.0.2",
-            "read-chunk": "2.1.0",
-            "read-pkg-up": "2.0.0",
-            "rimraf": "2.6.2",
-            "run-async": "2.3.0",
-            "shelljs": "0.7.8",
-            "text-table": "0.2.0",
-            "through2": "2.0.3",
-            "user-home": "2.0.0",
-            "yeoman-environment": "1.6.6"
-          },
-          "dependencies": {
-            "inquirer": {
-              "version": "1.2.3",
-              "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
-              "integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
-              "dev": true,
-              "requires": {
-                "ansi-escapes": "1.4.0",
+        "is-regexp": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+            "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+            "dev": true
+        },
+        "is-resolvable": {
+            "version": "1.1.0",
+            "resolved":
+                "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+            "integrity":
+                "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+            "dev": true
+        },
+        "is-retry-allowed": {
+            "version": "1.1.0",
+            "resolved":
+                "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+            "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
+        },
+        "is-scoped": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/is-scoped/-/is-scoped-1.0.0.tgz",
+            "integrity": "sha1-RJypgpnnEwOCViieyytUDcQ3yzA=",
+            "requires": {
+                "scoped-regex": "1.0.0"
+            }
+        },
+        "is-ssh": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.0.tgz",
+            "integrity": "sha1-6+oRaaJhTaOSpjdANmw84EnY3/Y=",
+            "dev": true,
+            "requires": {
+                "protocols": "1.4.6"
+            }
+        },
+        "is-stream": {
+            "version": "1.1.0",
+            "resolved":
+                "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+        },
+        "is-subset": {
+            "version": "0.1.1",
+            "resolved":
+                "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+            "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
+            "dev": true
+        },
+        "is-symbol": {
+            "version": "1.0.1",
+            "resolved":
+                "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+            "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+            "dev": true
+        },
+        "is-text-path": {
+            "version": "1.0.1",
+            "resolved":
+                "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
+            "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
+            "dev": true,
+            "requires": {
+                "text-extensions": "1.7.0"
+            }
+        },
+        "is-typedarray": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+            "dev": true
+        },
+        "is-utf8": {
+            "version": "0.2.1",
+            "resolved":
+                "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+            "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+        },
+        "is-windows": {
+            "version": "1.0.2",
+            "resolved":
+                "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+            "integrity":
+                "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+        },
+        "isarray": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "isbinaryfile": {
+            "version": "3.0.2",
+            "resolved":
+                "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.2.tgz",
+            "integrity": "sha1-Sj6XTsDLqQBNP8bN5yCeppNopiE="
+        },
+        "isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+        },
+        "isobject": {
+            "version": "3.0.1",
+            "resolved":
+                "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+            "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        },
+        "isstream": {
+            "version": "0.1.2",
+            "resolved":
+                "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+            "dev": true
+        },
+        "issue-parser": {
+            "version": "2.0.0",
+            "resolved":
+                "https://registry.npmjs.org/issue-parser/-/issue-parser-2.0.0.tgz",
+            "integrity":
+                "sha512-+dBeNWTdqfC4GX+xJMFmLuzYxY/ve9tUxU1V1INcdq+7c2bbTEojrk14vli1JcGzI0tFCXrF8Ys3hX8J+1NVjw==",
+            "dev": true,
+            "requires": {
+                "lodash": "4.17.10"
+            }
+        },
+        "istanbul-api": {
+            "version": "1.3.1",
+            "resolved":
+                "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.3.1.tgz",
+            "integrity":
+                "sha512-duj6AlLcsWNwUpfyfHt0nWIeRiZpuShnP40YTxOGQgtaN8fd6JYSxsvxUphTDy8V5MfDXo4s/xVCIIvVCO808g==",
+            "dev": true,
+            "requires": {
+                "async": "2.6.0",
+                "compare-versions": "3.2.1",
+                "fileset": "2.0.3",
+                "istanbul-lib-coverage": "1.2.0",
+                "istanbul-lib-hook": "1.2.0",
+                "istanbul-lib-instrument": "1.10.1",
+                "istanbul-lib-report": "1.1.4",
+                "istanbul-lib-source-maps": "1.2.4",
+                "istanbul-reports": "1.3.0",
+                "js-yaml": "3.11.0",
+                "mkdirp": "0.5.1",
+                "once": "1.4.0"
+            },
+            "dependencies": {
+                "istanbul-lib-source-maps": {
+                    "version": "1.2.4",
+                    "resolved":
+                        "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.4.tgz",
+                    "integrity":
+                        "sha512-UzuK0g1wyQijiaYQxj/CdNycFhAd2TLtO2obKQMTZrZ1jzEMRY3rvpASEKkaxbRR6brvdovfA03znPa/pXcejg==",
+                    "dev": true,
+                    "requires": {
+                        "debug": "3.1.0",
+                        "istanbul-lib-coverage": "1.2.0",
+                        "mkdirp": "0.5.1",
+                        "rimraf": "2.6.2",
+                        "source-map": "0.5.7"
+                    }
+                }
+            }
+        },
+        "istanbul-lib-coverage": {
+            "version": "1.2.0",
+            "resolved":
+                "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz",
+            "integrity":
+                "sha512-GvgM/uXRwm+gLlvkWHTjDAvwynZkL9ns15calTrmhGgowlwJBbWMYzWbKqE2DT6JDP1AFXKa+Zi0EkqNCUqY0A==",
+            "dev": true
+        },
+        "istanbul-lib-hook": {
+            "version": "1.2.0",
+            "resolved":
+                "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.0.tgz",
+            "integrity":
+                "sha512-p3En6/oGkFQV55Up8ZPC2oLxvgSxD8CzA0yBrhRZSh3pfv3OFj9aSGVC0yoerAi/O4u7jUVnOGVX1eVFM+0tmQ==",
+            "dev": true,
+            "requires": {
+                "append-transform": "0.4.0"
+            }
+        },
+        "istanbul-lib-instrument": {
+            "version": "1.10.1",
+            "resolved":
+                "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz",
+            "integrity":
+                "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
+            "dev": true,
+            "requires": {
+                "babel-generator": "6.26.1",
+                "babel-template": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0",
+                "istanbul-lib-coverage": "1.2.0",
+                "semver": "5.5.0"
+            }
+        },
+        "istanbul-lib-report": {
+            "version": "1.1.4",
+            "resolved":
+                "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.4.tgz",
+            "integrity":
+                "sha512-Azqvq5tT0U09nrncK3q82e/Zjkxa4tkFZv7E6VcqP0QCPn6oNljDPfrZEC/umNXds2t7b8sRJfs6Kmpzt8m2kA==",
+            "dev": true,
+            "requires": {
+                "istanbul-lib-coverage": "1.2.0",
+                "mkdirp": "0.5.1",
+                "path-parse": "1.0.5",
+                "supports-color": "3.2.3"
+            },
+            "dependencies": {
+                "has-flag": {
+                    "version": "1.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "3.2.3",
+                    "resolved":
+                        "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "1.0.0"
+                    }
+                }
+            }
+        },
+        "istanbul-lib-source-maps": {
+            "version": "1.2.3",
+            "resolved":
+                "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz",
+            "integrity":
+                "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
+            "dev": true,
+            "requires": {
+                "debug": "3.1.0",
+                "istanbul-lib-coverage": "1.2.0",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2",
+                "source-map": "0.5.7"
+            }
+        },
+        "istanbul-reports": {
+            "version": "1.3.0",
+            "resolved":
+                "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.3.0.tgz",
+            "integrity":
+                "sha512-y2Z2IMqE1gefWUaVjrBm0mSKvUkaBy9Vqz8iwr/r40Y9hBbIteH5wqHG/9DLTfJ9xUnUT2j7A3+VVJ6EaYBllA==",
+            "dev": true,
+            "requires": {
+                "handlebars": "4.0.11"
+            }
+        },
+        "istextorbinary": {
+            "version": "2.2.1",
+            "resolved":
+                "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.2.1.tgz",
+            "integrity":
+                "sha512-TS+hoFl8Z5FAFMK38nhBkdLt44CclNRgDHWeMgsV8ko3nDlr/9UI2Sf839sW7enijf8oKsZYXRvM8g0it9Zmcw==",
+            "requires": {
+                "binaryextensions": "2.1.1",
+                "editions": "1.3.4",
+                "textextensions": "2.2.0"
+            }
+        },
+        "isurl": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
+            "integrity":
+                "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+            "requires": {
+                "has-to-string-tag-x": "1.4.1",
+                "is-object": "1.0.1"
+            }
+        },
+        "java-properties": {
+            "version": "0.2.10",
+            "resolved":
+                "https://registry.npmjs.org/java-properties/-/java-properties-0.2.10.tgz",
+            "integrity":
+                "sha512-CpKJh9VRNhS+XqZtg1UMejETGEiqwCGDC/uwPEEQwc2nfdbSm73SIE29TplG2gLYuBOOTNDqxzG6A9NtEPLt0w==",
+            "dev": true
+        },
+        "jest": {
+            "version": "22.4.3",
+            "resolved": "https://registry.npmjs.org/jest/-/jest-22.4.3.tgz",
+            "integrity":
+                "sha512-FFCdU/pXOEASfHxFDOWUysI/+FFoqiXJADEIXgDKuZyqSmBD3tZ4BEGH7+M79v7czj7bbkhwtd2LaEDcJiM/GQ==",
+            "dev": true,
+            "requires": {
+                "import-local": "1.0.0",
+                "jest-cli": "22.4.3"
+            }
+        },
+        "jest-changed-files": {
+            "version": "22.4.3",
+            "resolved":
+                "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-22.4.3.tgz",
+            "integrity":
+                "sha512-83Dh0w1aSkUNFhy5d2dvqWxi/y6weDwVVLU6vmK0cV9VpRxPzhTeGimbsbRDSnEoszhF937M4sDLLeS7Cu/Tmw==",
+            "dev": true,
+            "requires": {
+                "throat": "4.1.0"
+            }
+        },
+        "jest-cli": {
+            "version": "22.4.3",
+            "resolved":
+                "https://registry.npmjs.org/jest-cli/-/jest-cli-22.4.3.tgz",
+            "integrity":
+                "sha512-IiHybF0DJNqZPsbjn4Cy4vcqcmImpoFwNFnkehzVw8lTUSl4axZh5DHewu5bdpZF2Y5gUqFKYzH0FH4Qx2k+UA==",
+            "dev": true,
+            "requires": {
+                "ansi-escapes": "3.1.0",
+                "chalk": "2.4.1",
+                "exit": "0.1.2",
+                "glob": "7.1.2",
+                "graceful-fs": "4.1.11",
+                "import-local": "1.0.0",
+                "is-ci": "1.1.0",
+                "istanbul-api": "1.3.1",
+                "istanbul-lib-coverage": "1.2.0",
+                "istanbul-lib-instrument": "1.10.1",
+                "istanbul-lib-source-maps": "1.2.3",
+                "jest-changed-files": "22.4.3",
+                "jest-config": "22.4.3",
+                "jest-environment-jsdom": "22.4.3",
+                "jest-get-type": "22.4.3",
+                "jest-haste-map": "22.4.3",
+                "jest-message-util": "22.4.3",
+                "jest-regex-util": "22.4.3",
+                "jest-resolve-dependencies": "22.4.3",
+                "jest-runner": "22.4.3",
+                "jest-runtime": "22.4.3",
+                "jest-snapshot": "22.4.3",
+                "jest-util": "22.4.3",
+                "jest-validate": "22.4.3",
+                "jest-worker": "22.4.3",
+                "micromatch": "2.3.11",
+                "node-notifier": "5.2.1",
+                "realpath-native": "1.0.0",
+                "rimraf": "2.6.2",
+                "slash": "1.0.0",
+                "string-length": "2.0.0",
+                "strip-ansi": "4.0.0",
+                "which": "1.3.0",
+                "yargs": "10.1.2"
+            },
+            "dependencies": {
+                "arr-diff": {
+                    "version": "2.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                    "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+                    "dev": true,
+                    "requires": {
+                        "arr-flatten": "1.1.0"
+                    }
+                },
+                "array-unique": {
+                    "version": "0.2.1",
+                    "resolved":
+                        "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+                    "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+                    "dev": true
+                },
+                "braces": {
+                    "version": "1.8.5",
+                    "resolved":
+                        "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+                    "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+                    "dev": true,
+                    "requires": {
+                        "expand-range": "1.8.2",
+                        "preserve": "0.2.0",
+                        "repeat-element": "1.1.2"
+                    }
+                },
+                "expand-brackets": {
+                    "version": "0.1.5",
+                    "resolved":
+                        "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+                    "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+                    "dev": true,
+                    "requires": {
+                        "is-posix-bracket": "0.1.1"
+                    }
+                },
+                "extglob": {
+                    "version": "0.3.2",
+                    "resolved":
+                        "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+                    "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "1.0.0"
+                    }
+                },
+                "is-extglob": {
+                    "version": "1.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                    "dev": true
+                },
+                "is-glob": {
+                    "version": "2.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "1.0.0"
+                    }
+                },
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved":
+                        "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                },
+                "micromatch": {
+                    "version": "2.3.11",
+                    "resolved":
+                        "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+                    "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+                    "dev": true,
+                    "requires": {
+                        "arr-diff": "2.0.0",
+                        "array-unique": "0.2.1",
+                        "braces": "1.8.5",
+                        "expand-brackets": "0.1.5",
+                        "extglob": "0.3.2",
+                        "filename-regex": "2.0.1",
+                        "is-extglob": "1.0.0",
+                        "is-glob": "2.0.1",
+                        "kind-of": "3.2.2",
+                        "normalize-path": "2.1.1",
+                        "object.omit": "2.0.1",
+                        "parse-glob": "3.0.4",
+                        "regex-cache": "0.4.4"
+                    }
+                }
+            }
+        },
+        "jest-config": {
+            "version": "22.4.3",
+            "resolved":
+                "https://registry.npmjs.org/jest-config/-/jest-config-22.4.3.tgz",
+            "integrity":
+                "sha512-KSg3EOToCgkX+lIvenKY7J8s426h6ahXxaUFJxvGoEk0562Z6inWj1TnKoGycTASwiLD+6kSYFALcjdosq9KIQ==",
+            "dev": true,
+            "requires": {
+                "chalk": "2.4.1",
+                "glob": "7.1.2",
+                "jest-environment-jsdom": "22.4.3",
+                "jest-environment-node": "22.4.3",
+                "jest-get-type": "22.4.3",
+                "jest-jasmine2": "22.4.3",
+                "jest-regex-util": "22.4.3",
+                "jest-resolve": "22.4.3",
+                "jest-util": "22.4.3",
+                "jest-validate": "22.4.3",
+                "pretty-format": "22.4.3"
+            }
+        },
+        "jest-diff": {
+            "version": "22.4.3",
+            "resolved":
+                "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.3.tgz",
+            "integrity":
+                "sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==",
+            "dev": true,
+            "requires": {
+                "chalk": "2.4.1",
+                "diff": "3.5.0",
+                "jest-get-type": "22.4.3",
+                "pretty-format": "22.4.3"
+            }
+        },
+        "jest-docblock": {
+            "version": "21.2.0",
+            "resolved":
+                "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
+            "integrity":
+                "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
+            "dev": true
+        },
+        "jest-environment-jsdom": {
+            "version": "22.4.3",
+            "resolved":
+                "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.4.3.tgz",
+            "integrity":
+                "sha512-FviwfR+VyT3Datf13+ULjIMO5CSeajlayhhYQwpzgunswoaLIPutdbrnfUHEMyJCwvqQFaVtTmn9+Y8WCt6n1w==",
+            "dev": true,
+            "requires": {
+                "jest-mock": "22.4.3",
+                "jest-util": "22.4.3",
+                "jsdom": "11.10.0"
+            }
+        },
+        "jest-environment-node": {
+            "version": "22.4.3",
+            "resolved":
+                "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.4.3.tgz",
+            "integrity":
+                "sha512-reZl8XF6t/lMEuPWwo9OLfttyC26A5AMgDyEQ6DBgZuyfyeNUzYT8BFo6uxCCP/Av/b7eb9fTi3sIHFPBzmlRA==",
+            "dev": true,
+            "requires": {
+                "jest-mock": "22.4.3",
+                "jest-util": "22.4.3"
+            }
+        },
+        "jest-get-type": {
+            "version": "22.4.3",
+            "resolved":
+                "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+            "integrity":
+                "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
+            "dev": true
+        },
+        "jest-haste-map": {
+            "version": "22.4.3",
+            "resolved":
+                "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.4.3.tgz",
+            "integrity":
+                "sha512-4Q9fjzuPVwnaqGKDpIsCSoTSnG3cteyk2oNVjBX12HHOaF1oxql+uUiqZb5Ndu7g/vTZfdNwwy4WwYogLh29DQ==",
+            "dev": true,
+            "requires": {
+                "fb-watchman": "2.0.0",
+                "graceful-fs": "4.1.11",
+                "jest-docblock": "22.4.3",
+                "jest-serializer": "22.4.3",
+                "jest-worker": "22.4.3",
+                "micromatch": "2.3.11",
+                "sane": "2.5.2"
+            },
+            "dependencies": {
+                "arr-diff": {
+                    "version": "2.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                    "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+                    "dev": true,
+                    "requires": {
+                        "arr-flatten": "1.1.0"
+                    }
+                },
+                "array-unique": {
+                    "version": "0.2.1",
+                    "resolved":
+                        "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+                    "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+                    "dev": true
+                },
+                "braces": {
+                    "version": "1.8.5",
+                    "resolved":
+                        "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+                    "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+                    "dev": true,
+                    "requires": {
+                        "expand-range": "1.8.2",
+                        "preserve": "0.2.0",
+                        "repeat-element": "1.1.2"
+                    }
+                },
+                "expand-brackets": {
+                    "version": "0.1.5",
+                    "resolved":
+                        "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+                    "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+                    "dev": true,
+                    "requires": {
+                        "is-posix-bracket": "0.1.1"
+                    }
+                },
+                "extglob": {
+                    "version": "0.3.2",
+                    "resolved":
+                        "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+                    "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "1.0.0"
+                    }
+                },
+                "is-extglob": {
+                    "version": "1.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                    "dev": true
+                },
+                "is-glob": {
+                    "version": "2.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "1.0.0"
+                    }
+                },
+                "jest-docblock": {
+                    "version": "22.4.3",
+                    "resolved":
+                        "https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.4.3.tgz",
+                    "integrity":
+                        "sha512-uPKBEAw7YrEMcXueMKZXn/rbMxBiSv48fSqy3uEnmgOlQhSX+lthBqHb1fKWNVmFqAp9E/RsSdBfiV31LbzaOg==",
+                    "dev": true,
+                    "requires": {
+                        "detect-newline": "2.1.0"
+                    }
+                },
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved":
+                        "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                },
+                "micromatch": {
+                    "version": "2.3.11",
+                    "resolved":
+                        "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+                    "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+                    "dev": true,
+                    "requires": {
+                        "arr-diff": "2.0.0",
+                        "array-unique": "0.2.1",
+                        "braces": "1.8.5",
+                        "expand-brackets": "0.1.5",
+                        "extglob": "0.3.2",
+                        "filename-regex": "2.0.1",
+                        "is-extglob": "1.0.0",
+                        "is-glob": "2.0.1",
+                        "kind-of": "3.2.2",
+                        "normalize-path": "2.1.1",
+                        "object.omit": "2.0.1",
+                        "parse-glob": "3.0.4",
+                        "regex-cache": "0.4.4"
+                    }
+                }
+            }
+        },
+        "jest-jasmine2": {
+            "version": "22.4.3",
+            "resolved":
+                "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.4.3.tgz",
+            "integrity":
+                "sha512-yZCPCJUcEY6R5KJB/VReo1AYI2b+5Ky+C+JA1v34jndJsRcLpU4IZX4rFJn7yDTtdNbO/nNqg+3SDIPNH2ecnw==",
+            "dev": true,
+            "requires": {
+                "chalk": "2.4.1",
+                "co": "4.6.0",
+                "expect": "22.4.3",
+                "graceful-fs": "4.1.11",
+                "is-generator-fn": "1.0.0",
+                "jest-diff": "22.4.3",
+                "jest-matcher-utils": "22.4.3",
+                "jest-message-util": "22.4.3",
+                "jest-snapshot": "22.4.3",
+                "jest-util": "22.4.3",
+                "source-map-support": "0.5.6"
+            }
+        },
+        "jest-leak-detector": {
+            "version": "22.4.3",
+            "resolved":
+                "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-22.4.3.tgz",
+            "integrity":
+                "sha512-NZpR/Ls7+ndO57LuXROdgCGz2RmUdC541tTImL9bdUtU3WadgFGm0yV+Ok4Fuia/1rLAn5KaJ+i76L6e3zGJYQ==",
+            "dev": true,
+            "requires": {
+                "pretty-format": "22.4.3"
+            }
+        },
+        "jest-matcher-utils": {
+            "version": "22.4.3",
+            "resolved":
+                "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz",
+            "integrity":
+                "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
+            "dev": true,
+            "requires": {
+                "chalk": "2.4.1",
+                "jest-get-type": "22.4.3",
+                "pretty-format": "22.4.3"
+            }
+        },
+        "jest-message-util": {
+            "version": "22.4.3",
+            "resolved":
+                "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.3.tgz",
+            "integrity":
+                "sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "7.0.0-beta.47",
+                "chalk": "2.4.1",
+                "micromatch": "2.3.11",
+                "slash": "1.0.0",
+                "stack-utils": "1.0.1"
+            },
+            "dependencies": {
+                "arr-diff": {
+                    "version": "2.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                    "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+                    "dev": true,
+                    "requires": {
+                        "arr-flatten": "1.1.0"
+                    }
+                },
+                "array-unique": {
+                    "version": "0.2.1",
+                    "resolved":
+                        "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+                    "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+                    "dev": true
+                },
+                "braces": {
+                    "version": "1.8.5",
+                    "resolved":
+                        "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+                    "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+                    "dev": true,
+                    "requires": {
+                        "expand-range": "1.8.2",
+                        "preserve": "0.2.0",
+                        "repeat-element": "1.1.2"
+                    }
+                },
+                "expand-brackets": {
+                    "version": "0.1.5",
+                    "resolved":
+                        "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+                    "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+                    "dev": true,
+                    "requires": {
+                        "is-posix-bracket": "0.1.1"
+                    }
+                },
+                "extglob": {
+                    "version": "0.3.2",
+                    "resolved":
+                        "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+                    "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "1.0.0"
+                    }
+                },
+                "is-extglob": {
+                    "version": "1.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                    "dev": true
+                },
+                "is-glob": {
+                    "version": "2.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "1.0.0"
+                    }
+                },
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved":
+                        "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                },
+                "micromatch": {
+                    "version": "2.3.11",
+                    "resolved":
+                        "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+                    "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+                    "dev": true,
+                    "requires": {
+                        "arr-diff": "2.0.0",
+                        "array-unique": "0.2.1",
+                        "braces": "1.8.5",
+                        "expand-brackets": "0.1.5",
+                        "extglob": "0.3.2",
+                        "filename-regex": "2.0.1",
+                        "is-extglob": "1.0.0",
+                        "is-glob": "2.0.1",
+                        "kind-of": "3.2.2",
+                        "normalize-path": "2.1.1",
+                        "object.omit": "2.0.1",
+                        "parse-glob": "3.0.4",
+                        "regex-cache": "0.4.4"
+                    }
+                }
+            }
+        },
+        "jest-mock": {
+            "version": "22.4.3",
+            "resolved":
+                "https://registry.npmjs.org/jest-mock/-/jest-mock-22.4.3.tgz",
+            "integrity":
+                "sha512-+4R6mH5M1G4NK16CKg9N1DtCaFmuxhcIqF4lQK/Q1CIotqMs/XBemfpDPeVZBFow6iyUNu6EBT9ugdNOTT5o5Q==",
+            "dev": true
+        },
+        "jest-regex-util": {
+            "version": "22.4.3",
+            "resolved":
+                "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-22.4.3.tgz",
+            "integrity":
+                "sha512-LFg1gWr3QinIjb8j833bq7jtQopiwdAs67OGfkPrvy7uNUbVMfTXXcOKXJaeY5GgjobELkKvKENqq1xrUectWg==",
+            "dev": true
+        },
+        "jest-resolve": {
+            "version": "22.4.3",
+            "resolved":
+                "https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.4.3.tgz",
+            "integrity":
+                "sha512-u3BkD/MQBmwrOJDzDIaxpyqTxYH+XqAXzVJP51gt29H8jpj3QgKof5GGO2uPGKGeA1yTMlpbMs1gIQ6U4vcRhw==",
+            "dev": true,
+            "requires": {
+                "browser-resolve": "1.11.2",
+                "chalk": "2.4.1"
+            }
+        },
+        "jest-resolve-dependencies": {
+            "version": "22.4.3",
+            "resolved":
+                "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-22.4.3.tgz",
+            "integrity":
+                "sha512-06czCMVToSN8F2U4EvgSB1Bv/56gc7MpCftZ9z9fBgUQM7dzHGCMBsyfVA6dZTx8v0FDcnALf7hupeQxaBCvpA==",
+            "dev": true,
+            "requires": {
+                "jest-regex-util": "22.4.3"
+            }
+        },
+        "jest-runner": {
+            "version": "22.4.3",
+            "resolved":
+                "https://registry.npmjs.org/jest-runner/-/jest-runner-22.4.3.tgz",
+            "integrity":
+                "sha512-U7PLlQPRlWNbvOHWOrrVay9sqhBJmiKeAdKIkvX4n1G2tsvzLlf77nBD28GL1N6tGv4RmuTfI8R8JrkvCa+IBg==",
+            "dev": true,
+            "requires": {
+                "exit": "0.1.2",
+                "jest-config": "22.4.3",
+                "jest-docblock": "22.4.3",
+                "jest-haste-map": "22.4.3",
+                "jest-jasmine2": "22.4.3",
+                "jest-leak-detector": "22.4.3",
+                "jest-message-util": "22.4.3",
+                "jest-runtime": "22.4.3",
+                "jest-util": "22.4.3",
+                "jest-worker": "22.4.3",
+                "throat": "4.1.0"
+            },
+            "dependencies": {
+                "jest-docblock": {
+                    "version": "22.4.3",
+                    "resolved":
+                        "https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.4.3.tgz",
+                    "integrity":
+                        "sha512-uPKBEAw7YrEMcXueMKZXn/rbMxBiSv48fSqy3uEnmgOlQhSX+lthBqHb1fKWNVmFqAp9E/RsSdBfiV31LbzaOg==",
+                    "dev": true,
+                    "requires": {
+                        "detect-newline": "2.1.0"
+                    }
+                }
+            }
+        },
+        "jest-runtime": {
+            "version": "22.4.3",
+            "resolved":
+                "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.4.3.tgz",
+            "integrity":
+                "sha512-Eat/esQjevhx9BgJEC8udye+FfoJ2qvxAZfOAWshYGS22HydHn5BgsvPdTtt9cp0fSl5LxYOFA1Pja9Iz2Zt8g==",
+            "dev": true,
+            "requires": {
+                "babel-core": "6.26.3",
+                "babel-jest": "22.4.3",
+                "babel-plugin-istanbul": "4.1.6",
+                "chalk": "2.4.1",
+                "convert-source-map": "1.5.1",
+                "exit": "0.1.2",
+                "graceful-fs": "4.1.11",
+                "jest-config": "22.4.3",
+                "jest-haste-map": "22.4.3",
+                "jest-regex-util": "22.4.3",
+                "jest-resolve": "22.4.3",
+                "jest-util": "22.4.3",
+                "jest-validate": "22.4.3",
+                "json-stable-stringify": "1.0.1",
+                "micromatch": "2.3.11",
+                "realpath-native": "1.0.0",
+                "slash": "1.0.0",
+                "strip-bom": "3.0.0",
+                "write-file-atomic": "2.3.0",
+                "yargs": "10.1.2"
+            },
+            "dependencies": {
+                "arr-diff": {
+                    "version": "2.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                    "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+                    "dev": true,
+                    "requires": {
+                        "arr-flatten": "1.1.0"
+                    }
+                },
+                "array-unique": {
+                    "version": "0.2.1",
+                    "resolved":
+                        "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+                    "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+                    "dev": true
+                },
+                "braces": {
+                    "version": "1.8.5",
+                    "resolved":
+                        "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+                    "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+                    "dev": true,
+                    "requires": {
+                        "expand-range": "1.8.2",
+                        "preserve": "0.2.0",
+                        "repeat-element": "1.1.2"
+                    }
+                },
+                "expand-brackets": {
+                    "version": "0.1.5",
+                    "resolved":
+                        "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+                    "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+                    "dev": true,
+                    "requires": {
+                        "is-posix-bracket": "0.1.1"
+                    }
+                },
+                "extglob": {
+                    "version": "0.3.2",
+                    "resolved":
+                        "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+                    "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "1.0.0"
+                    }
+                },
+                "is-extglob": {
+                    "version": "1.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                    "dev": true
+                },
+                "is-glob": {
+                    "version": "2.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "1.0.0"
+                    }
+                },
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved":
+                        "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                },
+                "micromatch": {
+                    "version": "2.3.11",
+                    "resolved":
+                        "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+                    "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+                    "dev": true,
+                    "requires": {
+                        "arr-diff": "2.0.0",
+                        "array-unique": "0.2.1",
+                        "braces": "1.8.5",
+                        "expand-brackets": "0.1.5",
+                        "extglob": "0.3.2",
+                        "filename-regex": "2.0.1",
+                        "is-extglob": "1.0.0",
+                        "is-glob": "2.0.1",
+                        "kind-of": "3.2.2",
+                        "normalize-path": "2.1.1",
+                        "object.omit": "2.0.1",
+                        "parse-glob": "3.0.4",
+                        "regex-cache": "0.4.4"
+                    }
+                }
+            }
+        },
+        "jest-serializer": {
+            "version": "22.4.3",
+            "resolved":
+                "https://registry.npmjs.org/jest-serializer/-/jest-serializer-22.4.3.tgz",
+            "integrity":
+                "sha512-uPaUAppx4VUfJ0QDerpNdF43F68eqKWCzzhUlKNDsUPhjOon7ZehR4C809GCqh765FoMRtTVUVnGvIoskkYHiw==",
+            "dev": true
+        },
+        "jest-snapshot": {
+            "version": "22.4.3",
+            "resolved":
+                "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.4.3.tgz",
+            "integrity":
+                "sha512-JXA0gVs5YL0HtLDCGa9YxcmmV2LZbwJ+0MfyXBBc5qpgkEYITQFJP7XNhcHFbUvRiniRpRbGVfJrOoYhhGE0RQ==",
+            "dev": true,
+            "requires": {
+                "chalk": "2.4.1",
+                "jest-diff": "22.4.3",
+                "jest-matcher-utils": "22.4.3",
+                "mkdirp": "0.5.1",
+                "natural-compare": "1.4.0",
+                "pretty-format": "22.4.3"
+            }
+        },
+        "jest-util": {
+            "version": "22.4.3",
+            "resolved":
+                "https://registry.npmjs.org/jest-util/-/jest-util-22.4.3.tgz",
+            "integrity":
+                "sha512-rfDfG8wyC5pDPNdcnAlZgwKnzHvZDu8Td2NJI/jAGKEGxJPYiE4F0ss/gSAkG4778Y23Hvbz+0GMrDJTeo7RjQ==",
+            "dev": true,
+            "requires": {
+                "callsites": "2.0.0",
+                "chalk": "2.4.1",
+                "graceful-fs": "4.1.11",
+                "is-ci": "1.1.0",
+                "jest-message-util": "22.4.3",
+                "mkdirp": "0.5.1",
+                "source-map": "0.6.1"
+            },
+            "dependencies": {
+                "callsites": {
+                    "version": "2.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+                    "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved":
+                        "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity":
+                        "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "jest-validate": {
+            "version": "22.4.3",
+            "resolved":
+                "https://registry.npmjs.org/jest-validate/-/jest-validate-22.4.3.tgz",
+            "integrity":
+                "sha512-CfFM18W3GSP/xgmA4UouIx0ljdtfD2mjeBC6c89Gg17E44D4tQhAcTrZmf9djvipwU30kSTnk6CzcxdCCeSXfA==",
+            "dev": true,
+            "requires": {
+                "chalk": "2.4.1",
+                "jest-config": "22.4.3",
+                "jest-get-type": "22.4.3",
+                "leven": "2.1.0",
+                "pretty-format": "22.4.3"
+            }
+        },
+        "jest-worker": {
+            "version": "22.4.3",
+            "resolved":
+                "https://registry.npmjs.org/jest-worker/-/jest-worker-22.4.3.tgz",
+            "integrity":
+                "sha512-B1ucW4fI8qVAuZmicFxI1R3kr2fNeYJyvIQ1rKcuLYnenFV5K5aMbxFj6J0i00Ju83S8jP2d7Dz14+AvbIHRYQ==",
+            "dev": true,
+            "requires": {
+                "merge-stream": "1.0.1"
+            }
+        },
+        "js-tokens": {
+            "version": "3.0.2",
+            "resolved":
+                "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+            "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+            "dev": true
+        },
+        "js-yaml": {
+            "version": "3.11.0",
+            "resolved":
+                "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+            "integrity":
+                "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+            "dev": true,
+            "requires": {
+                "argparse": "1.0.10",
+                "esprima": "4.0.0"
+            }
+        },
+        "jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+            "dev": true,
+            "optional": true
+        },
+        "jsdom": {
+            "version": "11.10.0",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.10.0.tgz",
+            "integrity":
+                "sha512-x5No5FpJgBg3j5aBwA8ka6eGuS5IxbC8FOkmyccKvObtFT0bDMict/LOxINZsZGZSfGdNomLZ/qRV9Bpq/GIBA==",
+            "dev": true,
+            "requires": {
+                "abab": "1.0.4",
+                "acorn": "5.5.3",
+                "acorn-globals": "4.1.0",
+                "array-equal": "1.0.0",
+                "cssom": "0.3.2",
+                "cssstyle": "0.2.37",
+                "data-urls": "1.0.0",
+                "domexception": "1.0.1",
+                "escodegen": "1.9.1",
+                "html-encoding-sniffer": "1.0.2",
+                "left-pad": "1.3.0",
+                "nwmatcher": "1.4.4",
+                "parse5": "4.0.0",
+                "pn": "1.1.0",
+                "request": "2.86.0",
+                "request-promise-native": "1.0.5",
+                "sax": "1.2.4",
+                "symbol-tree": "3.2.2",
+                "tough-cookie": "2.3.4",
+                "w3c-hr-time": "1.0.1",
+                "webidl-conversions": "4.0.2",
+                "whatwg-encoding": "1.0.3",
+                "whatwg-mimetype": "2.1.0",
+                "whatwg-url": "6.4.1",
+                "ws": "4.1.0",
+                "xml-name-validator": "3.0.0"
+            }
+        },
+        "jsesc": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+            "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+            "dev": true
+        },
+        "json-parse-better-errors": {
+            "version": "1.0.2",
+            "resolved":
+                "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+            "integrity":
+                "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+        },
+        "json-schema": {
+            "version": "0.2.3",
+            "resolved":
+                "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+            "dev": true
+        },
+        "json-schema-traverse": {
+            "version": "0.3.1",
+            "resolved":
+                "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+            "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+            "dev": true
+        },
+        "json-stable-stringify": {
+            "version": "1.0.1",
+            "resolved":
+                "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+            "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+            "dev": true,
+            "requires": {
+                "jsonify": "0.0.0"
+            }
+        },
+        "json-stable-stringify-without-jsonify": {
+            "version": "1.0.1",
+            "resolved":
+                "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+            "dev": true
+        },
+        "json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved":
+                "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+            "dev": true
+        },
+        "json5": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+            "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+            "dev": true
+        },
+        "jsonfile": {
+            "version": "2.4.0",
+            "resolved":
+                "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+            "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "4.1.11"
+            }
+        },
+        "jsonify": {
+            "version": "0.0.0",
+            "resolved":
+                "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+            "dev": true
+        },
+        "jsonparse": {
+            "version": "1.3.1",
+            "resolved":
+                "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+            "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+            "dev": true
+        },
+        "JSONStream": {
+            "version": "1.3.2",
+            "resolved":
+                "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
+            "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
+            "dev": true,
+            "requires": {
+                "jsonparse": "1.3.1",
+                "through": "2.3.8"
+            }
+        },
+        "jsprim": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.2.3",
+                "verror": "1.10.0"
+            }
+        },
+        "just-extend": {
+            "version": "1.1.27",
+            "resolved":
+                "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
+            "integrity":
+                "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+            "dev": true
+        },
+        "kind-of": {
+            "version": "6.0.2",
+            "resolved":
+                "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+            "integrity":
+                "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+        },
+        "klaw": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+            "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "4.1.11"
+            }
+        },
+        "lazy-cache": {
+            "version": "1.0.4",
+            "resolved":
+                "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+            "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+            "dev": true,
+            "optional": true
+        },
+        "lcid": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+            "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+            "dev": true,
+            "requires": {
+                "invert-kv": "1.0.0"
+            }
+        },
+        "lcov-parse": {
+            "version": "0.0.10",
+            "resolved":
+                "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
+            "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
+            "dev": true
+        },
+        "left-pad": {
+            "version": "1.3.0",
+            "resolved":
+                "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+            "integrity":
+                "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
+            "dev": true
+        },
+        "leven": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+            "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+            "dev": true
+        },
+        "levn": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+            "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+            "dev": true,
+            "requires": {
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2"
+            }
+        },
+        "lint-staged": {
+            "version": "7.1.0",
+            "resolved":
+                "https://registry.npmjs.org/lint-staged/-/lint-staged-7.1.0.tgz",
+            "integrity":
+                "sha512-0l+PRD21v2zBRcfEIxjFMo2DiQ94wykRXH/aEw3aTMYUmnpTRPS1rc3DryPWf+qtK1Pjd51pLigHGopxgDMK5A==",
+            "dev": true,
+            "requires": {
+                "app-root-path": "2.0.1",
+                "chalk": "2.4.1",
+                "commander": "2.15.1",
+                "cosmiconfig": "4.0.0",
+                "debug": "3.1.0",
+                "dedent": "0.7.0",
+                "execa": "0.9.0",
+                "find-parent-dir": "0.3.0",
+                "is-glob": "4.0.0",
+                "is-windows": "1.0.2",
+                "jest-validate": "22.4.3",
+                "listr": "0.13.0",
+                "lodash": "4.17.10",
+                "log-symbols": "2.2.0",
+                "micromatch": "3.1.10",
+                "npm-which": "3.0.1",
+                "p-map": "1.2.0",
+                "path-is-inside": "1.0.2",
+                "pify": "3.0.0",
+                "please-upgrade-node": "3.0.2",
+                "staged-git-files": "1.1.1",
+                "string-argv": "0.0.2",
+                "stringify-object": "3.2.2"
+            },
+            "dependencies": {
+                "cross-spawn": {
+                    "version": "5.1.0",
+                    "resolved":
+                        "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+                    "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "4.1.3",
+                        "shebang-command": "1.2.0",
+                        "which": "1.3.0"
+                    }
+                },
+                "dedent": {
+                    "version": "0.7.0",
+                    "resolved":
+                        "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+                    "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+                    "dev": true
+                },
+                "execa": {
+                    "version": "0.9.0",
+                    "resolved":
+                        "https://registry.npmjs.org/execa/-/execa-0.9.0.tgz",
+                    "integrity":
+                        "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "5.1.0",
+                        "get-stream": "3.0.0",
+                        "is-stream": "1.1.0",
+                        "npm-run-path": "2.0.2",
+                        "p-finally": "1.0.0",
+                        "signal-exit": "3.0.2",
+                        "strip-eof": "1.0.0"
+                    }
+                }
+            }
+        },
+        "listr": {
+            "version": "0.13.0",
+            "resolved": "https://registry.npmjs.org/listr/-/listr-0.13.0.tgz",
+            "integrity": "sha1-ILsLowuuZg7oTMBQPfS+PVYjiH0=",
+            "dev": true,
+            "requires": {
+                "chalk": "1.1.3",
+                "cli-truncate": "0.2.1",
+                "figures": "1.7.0",
+                "indent-string": "2.1.0",
+                "is-observable": "0.2.0",
+                "is-promise": "2.1.0",
+                "is-stream": "1.1.0",
+                "listr-silent-renderer": "1.1.1",
+                "listr-update-renderer": "0.4.0",
+                "listr-verbose-renderer": "0.4.1",
+                "log-symbols": "1.0.2",
+                "log-update": "1.0.2",
+                "ora": "0.2.3",
+                "p-map": "1.2.0",
+                "rxjs": "5.5.10",
+                "stream-to-observable": "0.2.0",
+                "strip-ansi": "3.0.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved":
+                        "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved":
+                        "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved":
+                        "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
+                    }
+                },
+                "figures": {
+                    "version": "1.7.0",
+                    "resolved":
+                        "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+                    "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+                    "dev": true,
+                    "requires": {
+                        "escape-string-regexp": "1.0.5",
+                        "object-assign": "4.1.1"
+                    }
+                },
+                "log-symbols": {
+                    "version": "1.0.2",
+                    "resolved":
+                        "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+                    "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "1.1.3"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                }
+            }
+        },
+        "listr-silent-renderer": {
+            "version": "1.1.1",
+            "resolved":
+                "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+            "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
+            "dev": true
+        },
+        "listr-update-renderer": {
+            "version": "0.4.0",
+            "resolved":
+                "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz",
+            "integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
+            "dev": true,
+            "requires": {
+                "chalk": "1.1.3",
+                "cli-truncate": "0.2.1",
+                "elegant-spinner": "1.0.1",
+                "figures": "1.7.0",
+                "indent-string": "3.2.0",
+                "log-symbols": "1.0.2",
+                "log-update": "1.0.2",
+                "strip-ansi": "3.0.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved":
+                        "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved":
+                        "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved":
+                        "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
+                    }
+                },
+                "figures": {
+                    "version": "1.7.0",
+                    "resolved":
+                        "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+                    "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+                    "dev": true,
+                    "requires": {
+                        "escape-string-regexp": "1.0.5",
+                        "object-assign": "4.1.1"
+                    }
+                },
+                "indent-string": {
+                    "version": "3.2.0",
+                    "resolved":
+                        "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+                    "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+                    "dev": true
+                },
+                "log-symbols": {
+                    "version": "1.0.2",
+                    "resolved":
+                        "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+                    "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "1.1.3"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                }
+            }
+        },
+        "listr-verbose-renderer": {
+            "version": "0.4.1",
+            "resolved":
+                "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
+            "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
+            "dev": true,
+            "requires": {
                 "chalk": "1.1.3",
                 "cli-cursor": "1.0.2",
-                "cli-width": "2.2.0",
-                "external-editor": "1.1.1",
-                "figures": "1.7.0",
-                "lodash": "4.17.5",
-                "mute-stream": "0.0.6",
-                "pinkie-promise": "2.0.1",
-                "run-async": "2.3.0",
-                "rx": "4.1.0",
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "through": "2.3.8"
-              }
+                "date-fns": "1.29.0",
+                "figures": "1.7.0"
             },
-            "yeoman-environment": {
-              "version": "1.6.6",
-              "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-1.6.6.tgz",
-              "integrity": "sha1-zYX6Z9FWBg5EDXgH1+988NLR1nE=",
-              "dev": true,
-              "requires": {
-                "chalk": "1.1.3",
-                "debug": "2.6.9",
-                "diff": "2.2.3",
-                "escape-string-regexp": "1.0.5",
-                "globby": "4.1.0",
-                "grouped-queue": "0.3.3",
-                "inquirer": "1.2.3",
-                "lodash": "4.17.5",
-                "log-symbols": "1.0.2",
-                "mem-fs": "1.1.3",
-                "text-table": "0.2.0",
-                "untildify": "2.1.0"
-              }
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved":
+                        "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved":
+                        "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved":
+                        "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
+                    }
+                },
+                "cli-cursor": {
+                    "version": "1.0.2",
+                    "resolved":
+                        "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+                    "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+                    "dev": true,
+                    "requires": {
+                        "restore-cursor": "1.0.1"
+                    }
+                },
+                "figures": {
+                    "version": "1.7.0",
+                    "resolved":
+                        "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+                    "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+                    "dev": true,
+                    "requires": {
+                        "escape-string-regexp": "1.0.5",
+                        "object-assign": "4.1.1"
+                    }
+                },
+                "onetime": {
+                    "version": "1.1.0",
+                    "resolved":
+                        "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+                    "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+                    "dev": true
+                },
+                "restore-cursor": {
+                    "version": "1.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+                    "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+                    "dev": true,
+                    "requires": {
+                        "exit-hook": "1.1.1",
+                        "onetime": "1.1.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                }
             }
-          }
-        }
-      }
-    },
-    "yosay": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/yosay/-/yosay-2.0.2.tgz",
-      "integrity": "sha512-avX6nz2esp7IMXGag4gu6OyQBsMh/SEn+ZybGu3yKPlOTE6z9qJrzG/0X5vCq/e0rPFy0CUYCze0G5hL310ibA==",
-      "requires": {
-        "ansi-regex": "2.1.1",
-        "ansi-styles": "3.2.1",
-        "chalk": "1.1.3",
-        "cli-boxes": "1.0.0",
-        "pad-component": "0.0.1",
-        "string-width": "2.1.1",
-        "strip-ansi": "3.0.1",
-        "taketalk": "1.0.0",
-        "wrap-ansi": "2.1.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        "load-json-file": {
+            "version": "4.0.0",
+            "resolved":
+                "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+            "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+            "requires": {
+                "graceful-fs": "4.1.11",
+                "parse-json": "4.0.0",
+                "pify": "3.0.0",
+                "strip-bom": "3.0.0"
             }
-          }
+        },
+        "locate-path": {
+            "version": "2.0.0",
+            "resolved":
+                "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+            "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+            "requires": {
+                "p-locate": "2.0.0",
+                "path-exists": "3.0.0"
+            }
+        },
+        "lodash": {
+            "version": "4.17.10",
+            "resolved":
+                "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+            "integrity":
+                "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+        },
+        "lodash.assign": {
+            "version": "4.2.0",
+            "resolved":
+                "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+            "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+            "dev": true
+        },
+        "lodash.get": {
+            "version": "4.4.2",
+            "resolved":
+                "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+            "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+            "dev": true
+        },
+        "lodash.map": {
+            "version": "4.6.0",
+            "resolved":
+                "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
+            "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=",
+            "dev": true
+        },
+        "lodash.sortby": {
+            "version": "4.7.0",
+            "resolved":
+                "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+            "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+            "dev": true
+        },
+        "lodash.toarray": {
+            "version": "4.4.0",
+            "resolved":
+                "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
+            "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
+            "dev": true
+        },
+        "log-driver": {
+            "version": "1.2.7",
+            "resolved":
+                "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
+            "integrity":
+                "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
+            "dev": true
+        },
+        "log-symbols": {
+            "version": "2.2.0",
+            "resolved":
+                "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+            "integrity":
+                "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+            "requires": {
+                "chalk": "2.4.1"
+            }
+        },
+        "log-update": {
+            "version": "1.0.2",
+            "resolved":
+                "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
+            "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
+            "dev": true,
+            "requires": {
+                "ansi-escapes": "1.4.0",
+                "cli-cursor": "1.0.2"
+            },
+            "dependencies": {
+                "ansi-escapes": {
+                    "version": "1.4.0",
+                    "resolved":
+                        "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+                    "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+                    "dev": true
+                },
+                "cli-cursor": {
+                    "version": "1.0.2",
+                    "resolved":
+                        "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+                    "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+                    "dev": true,
+                    "requires": {
+                        "restore-cursor": "1.0.1"
+                    }
+                },
+                "onetime": {
+                    "version": "1.1.0",
+                    "resolved":
+                        "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+                    "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+                    "dev": true
+                },
+                "restore-cursor": {
+                    "version": "1.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+                    "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+                    "dev": true,
+                    "requires": {
+                        "exit-hook": "1.1.1",
+                        "onetime": "1.1.0"
+                    }
+                }
+            }
+        },
+        "lolex": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.6.0.tgz",
+            "integrity":
+                "sha512-e1UtIo1pbrIqEXib/yMjHciyqkng5lc0rrIbytgjmRgDR9+2ceNIAcwOWSgylRjoEP9VdVguCSRwnNmlbnOUwA==",
+            "dev": true
+        },
+        "longest": {
+            "version": "1.0.1",
+            "resolved":
+                "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+            "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+            "dev": true
+        },
+        "loose-envify": {
+            "version": "1.3.1",
+            "resolved":
+                "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+            "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+            "dev": true,
+            "requires": {
+                "js-tokens": "3.0.2"
+            }
+        },
+        "loud-rejection": {
+            "version": "1.6.0",
+            "resolved":
+                "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+            "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+            "dev": true,
+            "requires": {
+                "currently-unhandled": "0.4.1",
+                "signal-exit": "3.0.2"
+            }
+        },
+        "lowercase-keys": {
+            "version": "1.0.1",
+            "resolved":
+                "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+            "integrity":
+                "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+        },
+        "lru-cache": {
+            "version": "4.1.3",
+            "resolved":
+                "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+            "integrity":
+                "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+            "dev": true,
+            "requires": {
+                "pseudomap": "1.0.2",
+                "yallist": "2.1.2"
+            }
+        },
+        "make-dir": {
+            "version": "1.3.0",
+            "resolved":
+                "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+            "integrity":
+                "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+            "requires": {
+                "pify": "3.0.0"
+            }
+        },
+        "makeerror": {
+            "version": "1.0.11",
+            "resolved":
+                "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+            "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+            "dev": true,
+            "requires": {
+                "tmpl": "1.0.4"
+            }
+        },
+        "map-cache": {
+            "version": "0.2.2",
+            "resolved":
+                "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+            "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+        },
+        "map-obj": {
+            "version": "2.0.0",
+            "resolved":
+                "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+            "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+            "dev": true
+        },
+        "map-visit": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+            "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+            "requires": {
+                "object-visit": "1.0.1"
+            }
+        },
+        "marked": {
+            "version": "0.3.19",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+            "integrity":
+                "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
+            "dev": true
+        },
+        "marked-terminal": {
+            "version": "2.0.0",
+            "resolved":
+                "https://registry.npmjs.org/marked-terminal/-/marked-terminal-2.0.0.tgz",
+            "integrity": "sha1-Xq9Wi+ZvaGVBr6UqVYKAMQox3i0=",
+            "dev": true,
+            "requires": {
+                "cardinal": "1.0.0",
+                "chalk": "1.1.3",
+                "cli-table": "0.3.1",
+                "lodash.assign": "4.2.0",
+                "node-emoji": "1.8.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved":
+                        "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved":
+                        "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved":
+                        "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                }
+            }
+        },
+        "math-random": {
+            "version": "1.0.1",
+            "resolved":
+                "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
+            "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
+            "dev": true
+        },
+        "mem": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+            "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+            "dev": true,
+            "requires": {
+                "mimic-fn": "1.2.0"
+            }
+        },
+        "mem-fs": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/mem-fs/-/mem-fs-1.1.3.tgz",
+            "integrity": "sha1-uK6NLj/Lb10/kWXBLUVRoGXZicw=",
+            "requires": {
+                "through2": "2.0.3",
+                "vinyl": "1.2.0",
+                "vinyl-file": "2.0.0"
+            },
+            "dependencies": {
+                "clone": {
+                    "version": "1.0.4",
+                    "resolved":
+                        "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+                    "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+                },
+                "clone-stats": {
+                    "version": "0.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+                    "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
+                },
+                "replace-ext": {
+                    "version": "0.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+                    "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+                },
+                "vinyl": {
+                    "version": "1.2.0",
+                    "resolved":
+                        "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+                    "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+                    "requires": {
+                        "clone": "1.0.4",
+                        "clone-stats": "0.0.1",
+                        "replace-ext": "0.0.1"
+                    }
+                }
+            }
+        },
+        "mem-fs-editor": {
+            "version": "4.0.2",
+            "resolved":
+                "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-4.0.2.tgz",
+            "integrity":
+                "sha512-QHvdXLLNmwJXxKdf7x27aNUren6IoPxwcM8Sfd+S6/ddQQMcYdEtVKsh6ilpqMrU18VQuKZEaH0aCGt3JDbA0g==",
+            "requires": {
+                "commondir": "1.0.1",
+                "deep-extend": "0.5.1",
+                "ejs": "2.6.1",
+                "glob": "7.1.2",
+                "globby": "8.0.1",
+                "isbinaryfile": "3.0.2",
+                "mkdirp": "0.5.1",
+                "multimatch": "2.1.0",
+                "rimraf": "2.6.2",
+                "through2": "2.0.3",
+                "vinyl": "2.1.0"
+            }
+        },
+        "meow": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+            "integrity":
+                "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+            "dev": true,
+            "requires": {
+                "camelcase-keys": "4.2.0",
+                "decamelize-keys": "1.1.0",
+                "loud-rejection": "1.6.0",
+                "minimist": "1.2.0",
+                "minimist-options": "3.0.2",
+                "normalize-package-data": "2.4.0",
+                "read-pkg-up": "3.0.0",
+                "redent": "2.0.0",
+                "trim-newlines": "2.0.0"
+            }
+        },
+        "merge": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
+            "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
+            "dev": true
+        },
+        "merge-stream": {
+            "version": "1.0.1",
+            "resolved":
+                "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+            "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "2.3.6"
+            }
+        },
+        "merge2": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.2.tgz",
+            "integrity":
+                "sha512-bgM8twH86rWni21thii6WCMQMRMmwqqdW3sGWi9IipnVAszdLXRjwDwAnyrVXo6DuP3AjRMMttZKUB48QWIFGg=="
+        },
+        "micromatch": {
+            "version": "3.1.10",
+            "resolved":
+                "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+            "integrity":
+                "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+            "requires": {
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "braces": "2.3.2",
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "extglob": "2.0.4",
+                "fragment-cache": "0.2.1",
+                "kind-of": "6.0.2",
+                "nanomatch": "1.2.9",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
+            }
+        },
+        "mime": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
+            "integrity":
+                "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg==",
+            "dev": true
+        },
+        "mime-db": {
+            "version": "1.33.0",
+            "resolved":
+                "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+            "integrity":
+                "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+            "dev": true
+        },
+        "mime-types": {
+            "version": "2.1.18",
+            "resolved":
+                "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+            "integrity":
+                "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+            "dev": true,
+            "requires": {
+                "mime-db": "1.33.0"
+            }
+        },
+        "mimic-fn": {
+            "version": "1.2.0",
+            "resolved":
+                "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+            "integrity":
+                "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+        },
+        "mimic-response": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.0.tgz",
+            "integrity": "sha1-3z02Uqc/3ta5sLJBRub9BSNTRY4="
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved":
+                "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity":
+                "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "requires": {
+                "brace-expansion": "1.1.11"
+            }
+        },
+        "minimist": {
+            "version": "1.2.0",
+            "resolved":
+                "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "minimist-options": {
+            "version": "3.0.2",
+            "resolved":
+                "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
+            "integrity":
+                "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
+            "dev": true,
+            "requires": {
+                "arrify": "1.0.1",
+                "is-plain-obj": "1.1.0"
+            }
+        },
+        "mixin-deep": {
+            "version": "1.3.1",
+            "resolved":
+                "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+            "integrity":
+                "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+            "requires": {
+                "for-in": "1.0.2",
+                "is-extendable": "1.0.1"
+            },
+            "dependencies": {
+                "is-extendable": {
+                    "version": "1.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity":
+                        "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "requires": {
+                        "is-plain-object": "2.0.4"
+                    }
+                }
+            }
+        },
+        "mkdirp": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "requires": {
+                "minimist": "0.0.8"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "0.0.8",
+                    "resolved":
+                        "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+                }
+            }
+        },
+        "modify-values": {
+            "version": "1.0.1",
+            "resolved":
+                "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
+            "integrity":
+                "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
+            "dev": true
+        },
+        "ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "multimatch": {
+            "version": "2.1.0",
+            "resolved":
+                "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+            "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
+            "requires": {
+                "array-differ": "1.0.0",
+                "array-union": "1.0.2",
+                "arrify": "1.0.1",
+                "minimatch": "3.0.4"
+            }
+        },
+        "mute-stream": {
+            "version": "0.0.7",
+            "resolved":
+                "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+            "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+        },
+        "nan": {
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+            "integrity":
+                "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+            "dev": true,
+            "optional": true
+        },
+        "nanomatch": {
+            "version": "1.2.9",
+            "resolved":
+                "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
+            "integrity":
+                "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+            "requires": {
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "fragment-cache": "0.2.1",
+                "is-odd": "2.0.0",
+                "is-windows": "1.0.2",
+                "kind-of": "6.0.2",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
+            }
+        },
+        "natural-compare": {
+            "version": "1.4.0",
+            "resolved":
+                "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+            "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+            "dev": true
+        },
+        "nerf-dart": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
+            "integrity": "sha1-5tq3/r9a2Bbqgc9cYpxaDr3nLBo=",
+            "dev": true
+        },
+        "nice-try": {
+            "version": "1.0.4",
+            "resolved":
+                "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
+            "integrity":
+                "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA=="
+        },
+        "nise": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/nise/-/nise-1.3.3.tgz",
+            "integrity":
+                "sha512-v1J/FLUB9PfGqZLGDBhQqODkbLotP0WtLo9R4EJY2PPu5f5Xg4o0rA8FDlmrjFSv9vBBKcfnOSpfYYuu5RTHqg==",
+            "dev": true,
+            "requires": {
+                "@sinonjs/formatio": "2.0.0",
+                "just-extend": "1.1.27",
+                "lolex": "2.6.0",
+                "path-to-regexp": "1.7.0",
+                "text-encoding": "0.6.4"
+            }
+        },
+        "node-emoji": {
+            "version": "1.8.1",
+            "resolved":
+                "https://registry.npmjs.org/node-emoji/-/node-emoji-1.8.1.tgz",
+            "integrity":
+                "sha512-+ktMAh1Jwas+TnGodfCfjUbJKoANqPaJFN0z0iqh41eqD8dvguNzcitVSBSVK1pidz0AqGbLKcoVuVLRVZ/aVg==",
+            "dev": true,
+            "requires": {
+                "lodash.toarray": "4.4.0"
+            }
+        },
+        "node-fetch": {
+            "version": "2.1.2",
+            "resolved":
+                "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+            "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=",
+            "dev": true
+        },
+        "node-int64": {
+            "version": "0.4.0",
+            "resolved":
+                "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+            "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+            "dev": true
+        },
+        "node-notifier": {
+            "version": "5.2.1",
+            "resolved":
+                "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
+            "integrity":
+                "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
+            "dev": true,
+            "requires": {
+                "growly": "1.3.0",
+                "semver": "5.5.0",
+                "shellwords": "0.1.1",
+                "which": "1.3.0"
+            }
+        },
+        "nodesecurity-npm-utils": {
+            "version": "6.0.0",
+            "resolved":
+                "https://registry.npmjs.org/nodesecurity-npm-utils/-/nodesecurity-npm-utils-6.0.0.tgz",
+            "integrity":
+                "sha512-NLRle1woNaT2orR6fue2jNqkhxDTktgJj3sZxvR/8kp21pvOY7Gwlx5wvo0H8ZVPqdgd2nE2ADB9wDu5Cl8zNg==",
+            "dev": true
+        },
+        "normalize-package-data": {
+            "version": "2.4.0",
+            "resolved":
+                "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+            "integrity":
+                "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+            "requires": {
+                "hosted-git-info": "2.6.0",
+                "is-builtin-module": "1.0.0",
+                "semver": "5.5.0",
+                "validate-npm-package-license": "3.0.3"
+            }
+        },
+        "normalize-path": {
+            "version": "2.1.1",
+            "resolved":
+                "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+            "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+            "dev": true,
+            "requires": {
+                "remove-trailing-separator": "1.1.0"
+            }
+        },
+        "normalize-url": {
+            "version": "2.0.1",
+            "resolved":
+                "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
+            "integrity":
+                "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
+            "dev": true,
+            "requires": {
+                "prepend-http": "2.0.0",
+                "query-string": "5.1.1",
+                "sort-keys": "2.0.0"
+            },
+            "dependencies": {
+                "prepend-http": {
+                    "version": "2.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+                    "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+                    "dev": true
+                }
+            }
+        },
+        "npm-path": {
+            "version": "2.0.4",
+            "resolved":
+                "https://registry.npmjs.org/npm-path/-/npm-path-2.0.4.tgz",
+            "integrity":
+                "sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==",
+            "dev": true,
+            "requires": {
+                "which": "1.3.0"
+            }
+        },
+        "npm-run-path": {
+            "version": "2.0.2",
+            "resolved":
+                "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+            "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+            "dev": true,
+            "requires": {
+                "path-key": "2.0.1"
+            }
+        },
+        "npm-which": {
+            "version": "3.0.1",
+            "resolved":
+                "https://registry.npmjs.org/npm-which/-/npm-which-3.0.1.tgz",
+            "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
+            "dev": true,
+            "requires": {
+                "commander": "2.15.1",
+                "npm-path": "2.0.4",
+                "which": "1.3.0"
+            }
+        },
+        "nsp": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/nsp/-/nsp-3.2.1.tgz",
+            "integrity":
+                "sha512-dLmGi7IGixJEHKetErIH460MYiYIzAoxuVsloZFu9e1p9U8K0yULx7YQ1+VzrjZbB+wqq67ES1SfOvKVb/qMDQ==",
+            "dev": true,
+            "requires": {
+                "chalk": "2.4.1",
+                "cli-table2": "0.2.0",
+                "cvss": "1.0.2",
+                "https-proxy-agent": "2.2.1",
+                "inquirer": "3.3.0",
+                "nodesecurity-npm-utils": "6.0.0",
+                "semver": "5.5.0",
+                "wreck": "12.5.1",
+                "yargs": "9.0.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved":
+                        "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                },
+                "camelcase": {
+                    "version": "4.1.0",
+                    "resolved":
+                        "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                    "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+                    "dev": true
+                },
+                "cliui": {
+                    "version": "3.2.0",
+                    "resolved":
+                        "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+                    "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1",
+                        "wrap-ansi": "2.1.0"
+                    },
+                    "dependencies": {
+                        "string-width": {
+                            "version": "1.0.2",
+                            "resolved":
+                                "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                            "dev": true,
+                            "requires": {
+                                "code-point-at": "1.1.0",
+                                "is-fullwidth-code-point": "1.0.0",
+                                "strip-ansi": "3.0.1"
+                            }
+                        },
+                        "strip-ansi": {
+                            "version": "3.0.1",
+                            "resolved":
+                                "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "2.1.1"
+                            }
+                        }
+                    }
+                },
+                "inquirer": {
+                    "version": "3.3.0",
+                    "resolved":
+                        "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+                    "integrity":
+                        "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-escapes": "3.1.0",
+                        "chalk": "2.4.1",
+                        "cli-cursor": "2.1.0",
+                        "cli-width": "2.2.0",
+                        "external-editor": "2.2.0",
+                        "figures": "2.0.0",
+                        "lodash": "4.17.10",
+                        "mute-stream": "0.0.7",
+                        "run-async": "2.3.0",
+                        "rx-lite": "4.0.8",
+                        "rx-lite-aggregates": "4.0.8",
+                        "string-width": "2.1.1",
+                        "strip-ansi": "4.0.0",
+                        "through": "2.3.8"
+                    }
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                    "dev": true,
+                    "requires": {
+                        "number-is-nan": "1.0.1"
+                    }
+                },
+                "load-json-file": {
+                    "version": "2.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+                    "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "parse-json": "2.2.0",
+                        "pify": "2.3.0",
+                        "strip-bom": "3.0.0"
+                    }
+                },
+                "parse-json": {
+                    "version": "2.2.0",
+                    "resolved":
+                        "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                    "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+                    "dev": true,
+                    "requires": {
+                        "error-ex": "1.3.1"
+                    }
+                },
+                "path-type": {
+                    "version": "2.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+                    "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+                    "dev": true,
+                    "requires": {
+                        "pify": "2.3.0"
+                    }
+                },
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved":
+                        "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                    "dev": true
+                },
+                "read-pkg": {
+                    "version": "2.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+                    "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+                    "dev": true,
+                    "requires": {
+                        "load-json-file": "2.0.0",
+                        "normalize-package-data": "2.4.0",
+                        "path-type": "2.0.0"
+                    }
+                },
+                "read-pkg-up": {
+                    "version": "2.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+                    "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "2.1.0",
+                        "read-pkg": "2.0.0"
+                    }
+                },
+                "yargs": {
+                    "version": "9.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
+                    "integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "4.1.0",
+                        "cliui": "3.2.0",
+                        "decamelize": "1.2.0",
+                        "get-caller-file": "1.0.2",
+                        "os-locale": "2.1.0",
+                        "read-pkg-up": "2.0.0",
+                        "require-directory": "2.1.1",
+                        "require-main-filename": "1.0.1",
+                        "set-blocking": "2.0.0",
+                        "string-width": "2.1.1",
+                        "which-module": "2.0.0",
+                        "y18n": "3.2.1",
+                        "yargs-parser": "7.0.0"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "7.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+                    "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "4.1.0"
+                    }
+                }
+            }
+        },
+        "number-is-nan": {
+            "version": "1.0.1",
+            "resolved":
+                "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+        },
+        "nwmatcher": {
+            "version": "1.4.4",
+            "resolved":
+                "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
+            "integrity":
+                "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ==",
+            "dev": true
+        },
+        "oauth-sign": {
+            "version": "0.8.2",
+            "resolved":
+                "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+            "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+            "dev": true
+        },
+        "object-assign": {
+            "version": "4.1.1",
+            "resolved":
+                "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "dev": true
+        },
+        "object-copy": {
+            "version": "0.1.0",
+            "resolved":
+                "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+            "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+            "requires": {
+                "copy-descriptor": "0.1.1",
+                "define-property": "0.2.5",
+                "kind-of": "3.2.2"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved":
+                        "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "requires": {
+                        "is-descriptor": "0.1.6"
+                    }
+                },
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved":
+                        "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
+        "object-keys": {
+            "version": "1.0.11",
+            "resolved":
+                "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+            "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+            "dev": true
+        },
+        "object-visit": {
+            "version": "1.0.1",
+            "resolved":
+                "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+            "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+            "requires": {
+                "isobject": "3.0.1"
+            }
+        },
+        "object.getownpropertydescriptors": {
+            "version": "2.0.3",
+            "resolved":
+                "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+            "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+            "dev": true,
+            "requires": {
+                "define-properties": "1.1.2",
+                "es-abstract": "1.11.0"
+            }
+        },
+        "object.omit": {
+            "version": "2.0.1",
+            "resolved":
+                "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+            "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+            "dev": true,
+            "requires": {
+                "for-own": "0.1.5",
+                "is-extendable": "0.1.1"
+            }
+        },
+        "object.pick": {
+            "version": "1.3.0",
+            "resolved":
+                "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+            "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+            "requires": {
+                "isobject": "3.0.1"
+            }
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "requires": {
+                "wrappy": "1.0.2"
+            }
+        },
+        "onetime": {
+            "version": "2.0.1",
+            "resolved":
+                "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+            "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+            "requires": {
+                "mimic-fn": "1.2.0"
+            }
+        },
+        "optimist": {
+            "version": "0.6.1",
+            "resolved":
+                "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+            "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+            "dev": true,
+            "requires": {
+                "minimist": "0.0.10",
+                "wordwrap": "0.0.3"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "0.0.10",
+                    "resolved":
+                        "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                    "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+                    "dev": true
+                },
+                "wordwrap": {
+                    "version": "0.0.3",
+                    "resolved":
+                        "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                    "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+                    "dev": true
+                }
+            }
+        },
+        "optionator": {
+            "version": "0.8.2",
+            "resolved":
+                "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+            "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+            "dev": true,
+            "requires": {
+                "deep-is": "0.1.3",
+                "fast-levenshtein": "2.0.6",
+                "levn": "0.3.0",
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2",
+                "wordwrap": "1.0.0"
+            }
+        },
+        "ora": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
+            "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
+            "dev": true,
+            "requires": {
+                "chalk": "1.1.3",
+                "cli-cursor": "1.0.2",
+                "cli-spinners": "0.1.2",
+                "object-assign": "4.1.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved":
+                        "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved":
+                        "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved":
+                        "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
+                    }
+                },
+                "cli-cursor": {
+                    "version": "1.0.2",
+                    "resolved":
+                        "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+                    "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+                    "dev": true,
+                    "requires": {
+                        "restore-cursor": "1.0.1"
+                    }
+                },
+                "onetime": {
+                    "version": "1.1.0",
+                    "resolved":
+                        "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+                    "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+                    "dev": true
+                },
+                "restore-cursor": {
+                    "version": "1.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+                    "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+                    "dev": true,
+                    "requires": {
+                        "exit-hook": "1.1.1",
+                        "onetime": "1.1.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                }
+            }
+        },
+        "os-homedir": {
+            "version": "1.0.2",
+            "resolved":
+                "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+            "dev": true
+        },
+        "os-locale": {
+            "version": "2.1.0",
+            "resolved":
+                "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+            "integrity":
+                "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+            "dev": true,
+            "requires": {
+                "execa": "0.7.0",
+                "lcid": "1.0.0",
+                "mem": "1.1.0"
+            }
+        },
+        "os-shim": {
+            "version": "0.1.3",
+            "resolved":
+                "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
+            "integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc=",
+            "dev": true
+        },
+        "os-tmpdir": {
+            "version": "1.0.2",
+            "resolved":
+                "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+        },
+        "p-cancelable": {
+            "version": "0.3.0",
+            "resolved":
+                "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
+            "integrity":
+                "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
+        },
+        "p-filter": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/p-filter/-/p-filter-1.0.0.tgz",
+            "integrity": "sha1-Yp0xcVAgnI/VCLoTdxPvS7kg6ds=",
+            "dev": true,
+            "requires": {
+                "p-map": "1.2.0"
+            }
+        },
+        "p-finally": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+        },
+        "p-is-promise": {
+            "version": "1.1.0",
+            "resolved":
+                "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+            "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
+            "dev": true
+        },
+        "p-limit": {
+            "version": "1.2.0",
+            "resolved":
+                "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+            "integrity":
+                "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+            "requires": {
+                "p-try": "1.0.0"
+            }
+        },
+        "p-locate": {
+            "version": "2.0.0",
+            "resolved":
+                "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+            "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+            "requires": {
+                "p-limit": "1.2.0"
+            }
+        },
+        "p-map": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+            "integrity":
+                "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+            "dev": true
+        },
+        "p-reduce": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
+            "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
+            "dev": true
+        },
+        "p-retry": {
+            "version": "2.0.0",
+            "resolved":
+                "https://registry.npmjs.org/p-retry/-/p-retry-2.0.0.tgz",
+            "integrity":
+                "sha512-ZbCuzAmiwJ45q4evp/IG9D+5MUllGSUeCWwPt3j/tdYSi1KPkSD+46uqmAA1LhccDhOXv8kYZKNb8x78VflzfA==",
+            "dev": true,
+            "requires": {
+                "retry": "0.12.0"
+            }
+        },
+        "p-timeout": {
+            "version": "1.2.1",
+            "resolved":
+                "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
+            "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
+            "requires": {
+                "p-finally": "1.0.0"
+            }
+        },
+        "p-try": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+            "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+        },
+        "pad-component": {
+            "version": "0.0.1",
+            "resolved":
+                "https://registry.npmjs.org/pad-component/-/pad-component-0.0.1.tgz",
+            "integrity": "sha1-rR8izhvw/cDW3dkIrxfzUaQEuKw="
+        },
+        "pad-right": {
+            "version": "0.2.2",
+            "resolved":
+                "https://registry.npmjs.org/pad-right/-/pad-right-0.2.2.tgz",
+            "integrity": "sha1-b7ySQEXSRPKiokRQMGDTv8YAl3Q=",
+            "dev": true,
+            "requires": {
+                "repeat-string": "1.6.1"
+            }
+        },
+        "parse-domain": {
+            "version": "2.0.0",
+            "resolved":
+                "https://registry.npmjs.org/parse-domain/-/parse-domain-2.0.0.tgz",
+            "integrity":
+                "sha512-09LkZIoBmYFj5Ty0oO1cjevbc42/knoiWURPUgKjJHlnK+75KDaF8+DNyEM5IYozO4Ssh6mNVOhrAKRWrwZbqQ==",
+            "dev": true
+        },
+        "parse-github-url": {
+            "version": "1.0.2",
+            "resolved":
+                "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.2.tgz",
+            "integrity":
+                "sha512-kgBf6avCbO3Cn6+RnzRGLkUsv4ZVqv/VfAYkRsyBcgkshNvVBkRn1FEZcW0Jb+npXQWm2vHPnnOqFteZxRRGNw==",
+            "dev": true
+        },
+        "parse-glob": {
+            "version": "3.0.4",
+            "resolved":
+                "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+            "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+            "dev": true,
+            "requires": {
+                "glob-base": "0.3.0",
+                "is-dotfile": "1.0.3",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1"
+            },
+            "dependencies": {
+                "is-extglob": {
+                    "version": "1.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                    "dev": true
+                },
+                "is-glob": {
+                    "version": "2.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "1.0.0"
+                    }
+                }
+            }
+        },
+        "parse-json": {
+            "version": "4.0.0",
+            "resolved":
+                "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+            "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+            "requires": {
+                "error-ex": "1.3.1",
+                "json-parse-better-errors": "1.0.2"
+            }
+        },
+        "parse-passwd": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+            "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+            "dev": true
+        },
+        "parse-url": {
+            "version": "1.3.11",
+            "resolved":
+                "https://registry.npmjs.org/parse-url/-/parse-url-1.3.11.tgz",
+            "integrity": "sha1-V8FUKKuKiSsfQ4aWRccR0OFEtVQ=",
+            "dev": true,
+            "requires": {
+                "is-ssh": "1.3.0",
+                "protocols": "1.4.6"
+            }
+        },
+        "parse5": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+            "integrity":
+                "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+            "dev": true
+        },
+        "pascalcase": {
+            "version": "0.1.1",
+            "resolved":
+                "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+            "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+        },
+        "path-dirname": {
+            "version": "1.0.2",
+            "resolved":
+                "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+            "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
+        },
+        "path-exists": {
+            "version": "3.0.0",
+            "resolved":
+                "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved":
+                "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+        },
+        "path-is-inside": {
+            "version": "1.0.2",
+            "resolved":
+                "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+            "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+            "dev": true
+        },
+        "path-key": {
+            "version": "2.0.1",
+            "resolved":
+                "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+        },
+        "path-parse": {
+            "version": "1.0.5",
+            "resolved":
+                "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+            "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+        },
+        "path-to-regexp": {
+            "version": "1.7.0",
+            "resolved":
+                "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+            "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+            "dev": true,
+            "requires": {
+                "isarray": "0.0.1"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "dev": true
+                }
+            }
+        },
+        "path-type": {
+            "version": "3.0.0",
+            "resolved":
+                "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+            "integrity":
+                "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+            "requires": {
+                "pify": "3.0.0"
+            }
+        },
+        "performance-now": {
+            "version": "2.1.0",
+            "resolved":
+                "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+            "dev": true
+        },
+        "pify": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+            "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        },
+        "pinkie": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+        },
+        "pinkie-promise": {
+            "version": "2.0.1",
+            "resolved":
+                "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+            "requires": {
+                "pinkie": "2.0.4"
+            }
+        },
+        "pkg-dir": {
+            "version": "2.0.0",
+            "resolved":
+                "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+            "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+            "dev": true,
+            "requires": {
+                "find-up": "2.1.0"
+            }
+        },
+        "please-upgrade-node": {
+            "version": "3.0.2",
+            "resolved":
+                "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.0.2.tgz",
+            "integrity":
+                "sha512-bslfSeW+ksUbB/sYZeEdKFyTG4YWU9YKRvqfSRvZKE675khAuBUPqV5RUwJZaGuWmVQLweK45Q+lPHFVnSlSug==",
+            "dev": true,
+            "requires": {
+                "semver-compare": "1.0.0"
+            }
+        },
+        "pluralize": {
+            "version": "7.0.0",
+            "resolved":
+                "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+            "integrity":
+                "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+            "dev": true
+        },
+        "pn": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+            "integrity":
+                "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+            "dev": true
+        },
+        "posix-character-classes": {
+            "version": "0.1.1",
+            "resolved":
+                "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+            "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+        },
+        "prelude-ls": {
+            "version": "1.1.2",
+            "resolved":
+                "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+            "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+            "dev": true
+        },
+        "prepend-http": {
+            "version": "1.0.4",
+            "resolved":
+                "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+            "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+        },
+        "preserve": {
+            "version": "0.2.0",
+            "resolved":
+                "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+            "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+            "dev": true
+        },
+        "prettier": {
+            "version": "1.12.1",
+            "resolved":
+                "https://registry.npmjs.org/prettier/-/prettier-1.12.1.tgz",
+            "integrity": "sha1-wa0g6APndJ+vkFpAnSNn4Gu+cyU=",
+            "dev": true
+        },
+        "pretty-bytes": {
+            "version": "4.0.2",
+            "resolved":
+                "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
+            "integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk="
+        },
+        "pretty-format": {
+            "version": "22.4.3",
+            "resolved":
+                "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
+            "integrity":
+                "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "3.0.0",
+                "ansi-styles": "3.2.1"
+            }
+        },
+        "private": {
+            "version": "0.1.8",
+            "resolved":
+                "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+            "integrity":
+                "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+            "dev": true
+        },
+        "process-nextick-args": {
+            "version": "2.0.0",
+            "resolved":
+                "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+            "integrity":
+                "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+        },
+        "progress": {
+            "version": "2.0.0",
+            "resolved":
+                "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+            "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+            "dev": true
+        },
+        "protocols": {
+            "version": "1.4.6",
+            "resolved":
+                "https://registry.npmjs.org/protocols/-/protocols-1.4.6.tgz",
+            "integrity": "sha1-+LsmPqG1/Xp2BNJri+Ob13Z4v4o=",
+            "dev": true
+        },
+        "pseudomap": {
+            "version": "1.0.2",
+            "resolved":
+                "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+            "dev": true
+        },
+        "punycode": {
+            "version": "1.4.1",
+            "resolved":
+                "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+            "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+            "dev": true
+        },
+        "q": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+            "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+            "dev": true
+        },
+        "qs": {
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+            "integrity":
+                "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+            "dev": true
+        },
+        "query-string": {
+            "version": "5.1.1",
+            "resolved":
+                "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+            "integrity":
+                "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+            "dev": true,
+            "requires": {
+                "decode-uri-component": "0.2.0",
+                "object-assign": "4.1.1",
+                "strict-uri-encode": "1.1.0"
+            }
+        },
+        "quick-lru": {
+            "version": "1.1.0",
+            "resolved":
+                "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
+            "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
+            "dev": true
+        },
+        "randomatic": {
+            "version": "3.0.0",
+            "resolved":
+                "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
+            "integrity":
+                "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
+            "dev": true,
+            "requires": {
+                "is-number": "4.0.0",
+                "kind-of": "6.0.2",
+                "math-random": "1.0.1"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "4.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+                    "integrity":
+                        "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+                    "dev": true
+                }
+            }
+        },
+        "rc": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
+            "integrity":
+                "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
+            "dev": true,
+            "requires": {
+                "deep-extend": "0.5.1",
+                "ini": "1.3.5",
+                "minimist": "1.2.0",
+                "strip-json-comments": "2.0.1"
+            }
+        },
+        "read-chunk": {
+            "version": "2.1.0",
+            "resolved":
+                "https://registry.npmjs.org/read-chunk/-/read-chunk-2.1.0.tgz",
+            "integrity": "sha1-agTAkoAF7Z1C4aasVgDhnLx/9lU=",
+            "requires": {
+                "pify": "3.0.0",
+                "safe-buffer": "5.1.2"
+            }
+        },
+        "read-pkg": {
+            "version": "3.0.0",
+            "resolved":
+                "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+            "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+            "requires": {
+                "load-json-file": "4.0.0",
+                "normalize-package-data": "2.4.0",
+                "path-type": "3.0.0"
+            }
+        },
+        "read-pkg-up": {
+            "version": "3.0.0",
+            "resolved":
+                "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+            "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+            "requires": {
+                "find-up": "2.1.0",
+                "read-pkg": "3.0.0"
+            }
+        },
+        "readable-stream": {
+            "version": "2.3.6",
+            "resolved":
+                "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+            "integrity":
+                "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+            "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.0",
+                "safe-buffer": "5.1.2",
+                "string_decoder": "1.1.1",
+                "util-deprecate": "1.0.2"
+            }
+        },
+        "realpath-native": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.0.tgz",
+            "integrity":
+                "sha512-XJtlRJ9jf0E1H1SLeJyQ9PGzQD7S65h1pRXEcAeK48doKOnKxcgPeNohJvD5u/2sI9J1oke6E8bZHS/fmW1UiQ==",
+            "dev": true,
+            "requires": {
+                "util.promisify": "1.0.0"
+            }
+        },
+        "rechoir": {
+            "version": "0.6.2",
+            "resolved":
+                "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+            "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+            "requires": {
+                "resolve": "1.7.1"
+            }
+        },
+        "redent": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+            "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+            "dev": true,
+            "requires": {
+                "indent-string": "3.2.0",
+                "strip-indent": "2.0.0"
+            },
+            "dependencies": {
+                "indent-string": {
+                    "version": "3.2.0",
+                    "resolved":
+                        "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+                    "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+                    "dev": true
+                }
+            }
+        },
+        "redeyed": {
+            "version": "1.0.1",
+            "resolved":
+                "https://registry.npmjs.org/redeyed/-/redeyed-1.0.1.tgz",
+            "integrity": "sha1-6WwZO0DAgWsArshCaY5hGF5VSYo=",
+            "dev": true,
+            "requires": {
+                "esprima": "3.0.0"
+            },
+            "dependencies": {
+                "esprima": {
+                    "version": "3.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/esprima/-/esprima-3.0.0.tgz",
+                    "integrity": "sha1-U88kes2ncxPlUcOqLnM0LT+099k=",
+                    "dev": true
+                }
+            }
+        },
+        "regenerator-runtime": {
+            "version": "0.11.1",
+            "resolved":
+                "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+            "integrity":
+                "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+            "dev": true
+        },
+        "regex-cache": {
+            "version": "0.4.4",
+            "resolved":
+                "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+            "integrity":
+                "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+            "dev": true,
+            "requires": {
+                "is-equal-shallow": "0.1.3"
+            }
+        },
+        "regex-not": {
+            "version": "1.0.2",
+            "resolved":
+                "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+            "integrity":
+                "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+            "requires": {
+                "extend-shallow": "3.0.2",
+                "safe-regex": "1.1.0"
+            }
+        },
+        "regexpp": {
+            "version": "1.1.0",
+            "resolved":
+                "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+            "integrity":
+                "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+            "dev": true
+        },
+        "registry-auth-token": {
+            "version": "3.3.2",
+            "resolved":
+                "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+            "integrity":
+                "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
+            "dev": true,
+            "requires": {
+                "rc": "1.2.7",
+                "safe-buffer": "5.1.2"
+            }
+        },
+        "remove-trailing-separator": {
+            "version": "1.1.0",
+            "resolved":
+                "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+        },
+        "repeat-element": {
+            "version": "1.1.2",
+            "resolved":
+                "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+            "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+        },
+        "repeat-string": {
+            "version": "1.6.1",
+            "resolved":
+                "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+        },
+        "repeating": {
+            "version": "2.0.1",
+            "resolved":
+                "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+            "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+            "dev": true,
+            "requires": {
+                "is-finite": "1.0.2"
+            }
+        },
+        "replace-ext": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+            "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+        },
+        "request": {
+            "version": "2.86.0",
+            "resolved":
+                "https://registry.npmjs.org/request/-/request-2.86.0.tgz",
+            "integrity":
+                "sha512-BQZih67o9r+Ys94tcIW4S7Uu8pthjrQVxhsZ/weOwHbDfACxvIyvnAbzFQxjy1jMtvFSzv5zf4my6cZsJBbVzw==",
+            "dev": true,
+            "requires": {
+                "aws-sign2": "0.7.0",
+                "aws4": "1.7.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.6",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.3.2",
+                "har-validator": "5.0.3",
+                "hawk": "6.0.2",
+                "http-signature": "1.2.0",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.18",
+                "oauth-sign": "0.8.2",
+                "performance-now": "2.1.0",
+                "qs": "6.5.2",
+                "safe-buffer": "5.1.2",
+                "tough-cookie": "2.3.4",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.2.1"
+            }
+        },
+        "request-promise-core": {
+            "version": "1.1.1",
+            "resolved":
+                "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+            "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+            "dev": true,
+            "requires": {
+                "lodash": "4.17.10"
+            }
+        },
+        "request-promise-native": {
+            "version": "1.0.5",
+            "resolved":
+                "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+            "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+            "dev": true,
+            "requires": {
+                "request-promise-core": "1.1.1",
+                "stealthy-require": "1.1.1",
+                "tough-cookie": "2.3.4"
+            }
+        },
+        "require-directory": {
+            "version": "2.1.1",
+            "resolved":
+                "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+            "dev": true
+        },
+        "require-from-string": {
+            "version": "2.0.2",
+            "resolved":
+                "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity":
+                "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "dev": true
+        },
+        "require-main-filename": {
+            "version": "1.0.1",
+            "resolved":
+                "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+            "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+            "dev": true
+        },
+        "require-uncached": {
+            "version": "1.0.3",
+            "resolved":
+                "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+            "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+            "dev": true,
+            "requires": {
+                "caller-path": "0.1.0",
+                "resolve-from": "1.0.1"
+            }
+        },
+        "resolve": {
+            "version": "1.7.1",
+            "resolved":
+                "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
+            "integrity":
+                "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+            "requires": {
+                "path-parse": "1.0.5"
+            }
+        },
+        "resolve-cwd": {
+            "version": "2.0.0",
+            "resolved":
+                "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+            "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+            "dev": true,
+            "requires": {
+                "resolve-from": "3.0.0"
+            },
+            "dependencies": {
+                "resolve-from": {
+                    "version": "3.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+                    "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+                    "dev": true
+                }
+            }
+        },
+        "resolve-dir": {
+            "version": "0.1.1",
+            "resolved":
+                "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+            "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
+            "dev": true,
+            "requires": {
+                "expand-tilde": "1.2.2",
+                "global-modules": "0.2.3"
+            }
+        },
+        "resolve-from": {
+            "version": "1.0.1",
+            "resolved":
+                "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+            "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+            "dev": true
+        },
+        "resolve-url": {
+            "version": "0.2.1",
+            "resolved":
+                "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+        },
+        "restore-cursor": {
+            "version": "2.0.0",
+            "resolved":
+                "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+            "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+            "requires": {
+                "onetime": "2.0.1",
+                "signal-exit": "3.0.2"
+            }
+        },
+        "ret": {
+            "version": "0.1.15",
+            "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+            "integrity":
+                "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+        },
+        "retry": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+            "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+            "dev": true
+        },
+        "right-align": {
+            "version": "0.1.3",
+            "resolved":
+                "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+            "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "align-text": "0.1.4"
+            }
+        },
+        "right-pad": {
+            "version": "1.0.1",
+            "resolved":
+                "https://registry.npmjs.org/right-pad/-/right-pad-1.0.1.tgz",
+            "integrity": "sha1-jKCMLLtbVedNr6lr9/0aJ9VoyNA=",
+            "dev": true
+        },
+        "rimraf": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+            "integrity":
+                "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+            "requires": {
+                "glob": "7.1.2"
+            }
+        },
+        "rsvp": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+            "integrity":
+                "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+            "dev": true
+        },
+        "run-async": {
+            "version": "2.3.0",
+            "resolved":
+                "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+            "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+            "requires": {
+                "is-promise": "2.1.0"
+            }
+        },
+        "rx": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
+            "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
+            "dev": true
+        },
+        "rx-lite": {
+            "version": "4.0.8",
+            "resolved":
+                "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+            "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+            "dev": true
+        },
+        "rx-lite-aggregates": {
+            "version": "4.0.8",
+            "resolved":
+                "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+            "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+            "dev": true,
+            "requires": {
+                "rx-lite": "4.0.8"
+            }
+        },
+        "rxjs": {
+            "version": "5.5.10",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.10.tgz",
+            "integrity":
+                "sha512-SRjimIDUHJkon+2hFo7xnvNC4ZEHGzCRwh9P7nzX3zPkCGFEg/tuElrNR7L/rZMagnK2JeH2jQwPRpmyXyLB6A==",
+            "requires": {
+                "symbol-observable": "1.0.1"
+            }
+        },
+        "safe-buffer": {
+            "version": "5.1.2",
+            "resolved":
+                "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity":
+                "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "safe-regex": {
+            "version": "1.1.0",
+            "resolved":
+                "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+            "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+            "requires": {
+                "ret": "0.1.15"
+            }
+        },
+        "safer-buffer": {
+            "version": "2.1.2",
+            "resolved":
+                "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity":
+                "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+        },
+        "samsam": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+            "integrity":
+                "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+            "dev": true
+        },
+        "sane": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/sane/-/sane-2.5.2.tgz",
+            "integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
+            "dev": true,
+            "requires": {
+                "anymatch": "2.0.0",
+                "capture-exit": "1.2.0",
+                "exec-sh": "0.2.1",
+                "fb-watchman": "2.0.0",
+                "fsevents": "1.2.4",
+                "micromatch": "3.1.10",
+                "minimist": "1.2.0",
+                "walker": "1.0.7",
+                "watch": "0.18.0"
+            }
+        },
+        "sax": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+            "integrity":
+                "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+            "dev": true
+        },
+        "scoped-regex": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/scoped-regex/-/scoped-regex-1.0.0.tgz",
+            "integrity": "sha1-o0a7Gs1CB65wvXwMfKnlZra63bg="
+        },
+        "semantic-release": {
+            "version": "15.4.1",
+            "resolved":
+                "https://registry.npmjs.org/semantic-release/-/semantic-release-15.4.1.tgz",
+            "integrity":
+                "sha512-mUAjrB39e/D720kDZFPrKEHukwsUnr8kLgXQXexjGbsmTt3RheBOIeIH7j4yKqyn/gDJb6MxMLfeU6Yu22z92w==",
+            "dev": true,
+            "requires": {
+                "@semantic-release/commit-analyzer": "5.0.3",
+                "@semantic-release/error": "2.2.0",
+                "@semantic-release/github": "4.2.16",
+                "@semantic-release/npm": "3.2.5",
+                "@semantic-release/release-notes-generator": "6.0.10",
+                "aggregate-error": "1.0.0",
+                "chalk": "2.4.1",
+                "cosmiconfig": "5.0.3",
+                "debug": "3.1.0",
+                "env-ci": "2.1.0",
+                "execa": "0.10.0",
+                "get-stream": "3.0.0",
+                "git-log-parser": "1.2.0",
+                "git-url-parse": "9.0.0",
+                "hook-std": "0.4.0",
+                "hosted-git-info": "2.6.0",
+                "lodash": "4.17.10",
+                "marked": "0.3.19",
+                "marked-terminal": "2.0.0",
+                "p-locate": "2.0.0",
+                "p-reduce": "1.0.0",
+                "read-pkg-up": "3.0.0",
+                "resolve-from": "4.0.0",
+                "semver": "5.5.0",
+                "yargs": "11.0.0"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "4.1.0",
+                    "resolved":
+                        "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                    "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+                    "dev": true
+                },
+                "cliui": {
+                    "version": "4.1.0",
+                    "resolved":
+                        "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+                    "integrity":
+                        "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "2.1.1",
+                        "strip-ansi": "4.0.0",
+                        "wrap-ansi": "2.1.0"
+                    }
+                },
+                "cosmiconfig": {
+                    "version": "5.0.3",
+                    "resolved":
+                        "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.3.tgz",
+                    "integrity":
+                        "sha512-x7vMpNH5favpvFjxwSzfQkB5ozdxikcmWzxah9aOh8BCOKeR+j6TM6PxQ2zyMm3+EDZcSajQrzzPKrsVqbsUDA==",
+                    "dev": true,
+                    "requires": {
+                        "is-directory": "0.3.1",
+                        "js-yaml": "3.11.0",
+                        "parse-json": "4.0.0"
+                    }
+                },
+                "execa": {
+                    "version": "0.10.0",
+                    "resolved":
+                        "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+                    "integrity":
+                        "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "6.0.5",
+                        "get-stream": "3.0.0",
+                        "is-stream": "1.1.0",
+                        "npm-run-path": "2.0.2",
+                        "p-finally": "1.0.0",
+                        "signal-exit": "3.0.2",
+                        "strip-eof": "1.0.0"
+                    }
+                },
+                "resolve-from": {
+                    "version": "4.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+                    "integrity":
+                        "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+                    "dev": true
+                },
+                "yargs": {
+                    "version": "11.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
+                    "integrity":
+                        "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "4.1.0",
+                        "decamelize": "1.2.0",
+                        "find-up": "2.1.0",
+                        "get-caller-file": "1.0.2",
+                        "os-locale": "2.1.0",
+                        "require-directory": "2.1.1",
+                        "require-main-filename": "1.0.1",
+                        "set-blocking": "2.0.0",
+                        "string-width": "2.1.1",
+                        "which-module": "2.0.0",
+                        "y18n": "3.2.1",
+                        "yargs-parser": "9.0.2"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "9.0.2",
+                    "resolved":
+                        "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+                    "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "4.1.0"
+                    }
+                }
+            }
+        },
+        "semver": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+            "integrity":
+                "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+        },
+        "semver-compare": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+            "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
+            "dev": true
+        },
+        "set-blocking": {
+            "version": "2.0.0",
+            "resolved":
+                "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+            "dev": true
+        },
+        "set-value": {
+            "version": "2.0.0",
+            "resolved":
+                "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+            "integrity":
+                "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+            "requires": {
+                "extend-shallow": "2.0.1",
+                "is-extendable": "0.1.1",
+                "is-plain-object": "2.0.4",
+                "split-string": "3.1.0"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "requires": {
+                        "is-extendable": "0.1.1"
+                    }
+                }
+            }
+        },
+        "shebang-command": {
+            "version": "1.2.0",
+            "resolved":
+                "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+            "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+            "requires": {
+                "shebang-regex": "1.0.0"
+            }
+        },
+        "shebang-regex": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+        },
+        "shelljs": {
+            "version": "0.8.2",
+            "resolved":
+                "https://registry.npmjs.org/shelljs/-/shelljs-0.8.2.tgz",
+            "integrity":
+                "sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
+            "requires": {
+                "glob": "7.1.2",
+                "interpret": "1.1.0",
+                "rechoir": "0.6.2"
+            }
+        },
+        "shellwords": {
+            "version": "0.1.1",
+            "resolved":
+                "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+            "integrity":
+                "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+            "dev": true
+        },
+        "signal-exit": {
+            "version": "3.0.2",
+            "resolved":
+                "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+        },
+        "sinon": {
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/sinon/-/sinon-5.0.7.tgz",
+            "integrity":
+                "sha512-GvNLrwpvLZ8jIMZBUhHGUZDq5wlUdceJWyHvZDmqBxnjazpxY1L0FNbGBX6VpcOEoQ8Q4XMWFzm2myJMvx+VjA==",
+            "dev": true,
+            "requires": {
+                "@sinonjs/formatio": "2.0.0",
+                "diff": "3.5.0",
+                "lodash.get": "4.4.2",
+                "lolex": "2.6.0",
+                "nise": "1.3.3",
+                "supports-color": "5.4.0",
+                "type-detect": "4.0.8"
+            }
+        },
+        "slash": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+            "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+        },
+        "slice-ansi": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+            "integrity":
+                "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+            "dev": true,
+            "requires": {
+                "is-fullwidth-code-point": "2.0.0"
+            }
+        },
+        "snapdragon": {
+            "version": "0.8.2",
+            "resolved":
+                "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+            "integrity":
+                "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+            "requires": {
+                "base": "0.11.2",
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "map-cache": "0.2.2",
+                "source-map": "0.5.7",
+                "source-map-resolve": "0.5.2",
+                "use": "3.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved":
+                        "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity":
+                        "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved":
+                        "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "requires": {
+                        "is-descriptor": "0.1.6"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "requires": {
+                        "is-extendable": "0.1.1"
+                    }
+                }
+            }
+        },
+        "snapdragon-node": {
+            "version": "2.1.1",
+            "resolved":
+                "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+            "integrity":
+                "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+            "requires": {
+                "define-property": "1.0.0",
+                "isobject": "3.0.1",
+                "snapdragon-util": "3.0.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "requires": {
+                        "is-descriptor": "1.0.2"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity":
+                        "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "requires": {
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity":
+                        "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "requires": {
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved":
+                        "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity":
+                        "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "requires": {
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
+                    }
+                }
+            }
+        },
+        "snapdragon-util": {
+            "version": "3.0.1",
+            "resolved":
+                "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+            "integrity":
+                "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+            "requires": {
+                "kind-of": "3.2.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved":
+                        "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
+        "sntp": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+            "integrity":
+                "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+            "dev": true,
+            "requires": {
+                "hoek": "4.2.1"
+            }
+        },
+        "sort-keys": {
+            "version": "2.0.0",
+            "resolved":
+                "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
+            "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+            "dev": true,
+            "requires": {
+                "is-plain-obj": "1.1.0"
+            }
+        },
+        "source-map": {
+            "version": "0.5.7",
+            "resolved":
+                "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        },
+        "source-map-resolve": {
+            "version": "0.5.2",
+            "resolved":
+                "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+            "integrity":
+                "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+            "requires": {
+                "atob": "2.1.1",
+                "decode-uri-component": "0.2.0",
+                "resolve-url": "0.2.1",
+                "source-map-url": "0.4.0",
+                "urix": "0.1.0"
+            }
+        },
+        "source-map-support": {
+            "version": "0.5.6",
+            "resolved":
+                "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
+            "integrity":
+                "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
+            "dev": true,
+            "requires": {
+                "buffer-from": "1.0.0",
+                "source-map": "0.6.1"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved":
+                        "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity":
+                        "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "source-map-url": {
+            "version": "0.4.0",
+            "resolved":
+                "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+            "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+        },
+        "spawn-error-forwarder": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/spawn-error-forwarder/-/spawn-error-forwarder-1.0.0.tgz",
+            "integrity": "sha1-Gv2Uc46ZmwNG17n8NzvlXgdXcCk=",
+            "dev": true
+        },
+        "spawn-sync": {
+            "version": "1.0.15",
+            "resolved":
+                "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
+            "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
+            "dev": true,
+            "requires": {
+                "concat-stream": "1.6.2",
+                "os-shim": "0.1.3"
+            }
+        },
+        "spdx-correct": {
+            "version": "3.0.0",
+            "resolved":
+                "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+            "integrity":
+                "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+            "requires": {
+                "spdx-expression-parse": "3.0.0",
+                "spdx-license-ids": "3.0.0"
+            }
+        },
+        "spdx-exceptions": {
+            "version": "2.1.0",
+            "resolved":
+                "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+            "integrity":
+                "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
+        },
+        "spdx-expression-parse": {
+            "version": "3.0.0",
+            "resolved":
+                "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+            "integrity":
+                "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+            "requires": {
+                "spdx-exceptions": "2.1.0",
+                "spdx-license-ids": "3.0.0"
+            }
+        },
+        "spdx-license-ids": {
+            "version": "3.0.0",
+            "resolved":
+                "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+            "integrity":
+                "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
+        },
+        "split": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+            "integrity":
+                "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+            "dev": true,
+            "requires": {
+                "through": "2.3.8"
+            }
+        },
+        "split-string": {
+            "version": "3.1.0",
+            "resolved":
+                "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+            "integrity":
+                "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+            "requires": {
+                "extend-shallow": "3.0.2"
+            }
+        },
+        "split2": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
+            "integrity":
+                "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+            "dev": true,
+            "requires": {
+                "through2": "2.0.3"
+            }
+        },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved":
+                "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
+        },
+        "sshpk": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
+            "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+            "dev": true,
+            "requires": {
+                "asn1": "0.2.3",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.1",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.1",
+                "getpass": "0.1.7",
+                "jsbn": "0.1.1",
+                "tweetnacl": "0.14.5"
+            }
+        },
+        "stack-utils": {
+            "version": "1.0.1",
+            "resolved":
+                "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
+            "integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
+            "dev": true
+        },
+        "staged-git-files": {
+            "version": "1.1.1",
+            "resolved":
+                "https://registry.npmjs.org/staged-git-files/-/staged-git-files-1.1.1.tgz",
+            "integrity":
+                "sha512-H89UNKr1rQJvI1c/PIR3kiAMBV23yvR7LItZiV74HWZwzt7f3YHuujJ9nJZlt58WlFox7XQsOahexwk7nTe69A==",
+            "dev": true
+        },
+        "static-extend": {
+            "version": "0.1.2",
+            "resolved":
+                "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+            "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+            "requires": {
+                "define-property": "0.2.5",
+                "object-copy": "0.1.0"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved":
+                        "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "requires": {
+                        "is-descriptor": "0.1.6"
+                    }
+                }
+            }
+        },
+        "stealthy-require": {
+            "version": "1.1.1",
+            "resolved":
+                "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+            "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+            "dev": true
+        },
+        "stream-combiner2": {
+            "version": "1.1.1",
+            "resolved":
+                "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+            "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
+            "dev": true,
+            "requires": {
+                "duplexer2": "0.1.4",
+                "readable-stream": "2.3.6"
+            }
+        },
+        "stream-to-observable": {
+            "version": "0.2.0",
+            "resolved":
+                "https://registry.npmjs.org/stream-to-observable/-/stream-to-observable-0.2.0.tgz",
+            "integrity": "sha1-WdbqOT2HwsDdrBCqDVYbxrpvDhA=",
+            "dev": true,
+            "requires": {
+                "any-observable": "0.2.0"
+            }
+        },
+        "strict-uri-encode": {
+            "version": "1.1.0",
+            "resolved":
+                "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+            "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+            "dev": true
+        },
+        "string_decoder": {
+            "version": "1.1.1",
+            "resolved":
+                "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity":
+                "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "requires": {
+                "safe-buffer": "5.1.2"
+            }
+        },
+        "string-argv": {
+            "version": "0.0.2",
+            "resolved":
+                "https://registry.npmjs.org/string-argv/-/string-argv-0.0.2.tgz",
+            "integrity": "sha1-2sMECGkMIfPDYwo/86BYd73L1zY=",
+            "dev": true
+        },
+        "string-length": {
+            "version": "2.0.0",
+            "resolved":
+                "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
+            "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
+            "dev": true,
+            "requires": {
+                "astral-regex": "1.0.0",
+                "strip-ansi": "4.0.0"
+            }
+        },
+        "string-template": {
+            "version": "0.2.1",
+            "resolved":
+                "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
+            "integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0="
+        },
+        "string-width": {
+            "version": "2.1.1",
+            "resolved":
+                "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+            "integrity":
+                "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+            "requires": {
+                "is-fullwidth-code-point": "2.0.0",
+                "strip-ansi": "4.0.0"
+            }
+        },
+        "stringify-object": {
+            "version": "3.2.2",
+            "resolved":
+                "https://registry.npmjs.org/stringify-object/-/stringify-object-3.2.2.tgz",
+            "integrity":
+                "sha512-O696NF21oLiDy8PhpWu8AEqoZHw++QW6mUv0UvKZe8gWSdSvMXkiLufK7OmnP27Dro4GU5kb9U7JIO0mBuCRQg==",
+            "dev": true,
+            "requires": {
+                "get-own-enumerable-property-symbols": "2.0.1",
+                "is-obj": "1.0.1",
+                "is-regexp": "1.0.0"
+            }
         },
         "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
+            "version": "4.0.0",
+            "resolved":
+                "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+            "requires": {
+                "ansi-regex": "3.0.0"
+            }
+        },
+        "strip-bom": {
+            "version": "3.0.0",
+            "resolved":
+                "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+            "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+        },
+        "strip-bom-stream": {
+            "version": "2.0.0",
+            "resolved":
+                "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz",
+            "integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
+            "requires": {
+                "first-chunk-stream": "2.0.0",
+                "strip-bom": "2.0.0"
+            },
+            "dependencies": {
+                "strip-bom": {
+                    "version": "2.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                    "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+                    "requires": {
+                        "is-utf8": "0.2.1"
+                    }
+                }
+            }
+        },
+        "strip-eof": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+            "dev": true
+        },
+        "strip-indent": {
+            "version": "2.0.0",
+            "resolved":
+                "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+            "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+            "dev": true
+        },
+        "strip-json-comments": {
+            "version": "2.0.1",
+            "resolved":
+                "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+            "dev": true
         },
         "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+            "version": "5.4.0",
+            "resolved":
+                "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+            "integrity":
+                "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+            "requires": {
+                "has-flag": "3.0.0"
+            }
+        },
+        "symbol-observable": {
+            "version": "1.0.1",
+            "resolved":
+                "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+            "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
+        },
+        "symbol-tree": {
+            "version": "3.2.2",
+            "resolved":
+                "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+            "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+            "dev": true
+        },
+        "table": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+            "integrity":
+                "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+            "dev": true,
+            "requires": {
+                "ajv": "5.5.2",
+                "ajv-keywords": "2.1.1",
+                "chalk": "2.4.1",
+                "lodash": "4.17.10",
+                "slice-ansi": "1.0.0",
+                "string-width": "2.1.1"
+            }
+        },
+        "taketalk": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/taketalk/-/taketalk-1.0.0.tgz",
+            "integrity": "sha1-tNTw3u0gauffd1sSnqLKbeUvJt0=",
+            "requires": {
+                "get-stdin": "4.0.1",
+                "minimist": "1.2.0"
+            }
+        },
+        "test-exclude": {
+            "version": "4.2.1",
+            "resolved":
+                "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.1.tgz",
+            "integrity":
+                "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
+            "dev": true,
+            "requires": {
+                "arrify": "1.0.1",
+                "micromatch": "3.1.10",
+                "object-assign": "4.1.1",
+                "read-pkg-up": "1.0.1",
+                "require-main-filename": "1.0.1"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "1.1.2",
+                    "resolved":
+                        "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+                    "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+                    "dev": true,
+                    "requires": {
+                        "path-exists": "2.1.0",
+                        "pinkie-promise": "2.0.1"
+                    }
+                },
+                "load-json-file": {
+                    "version": "1.1.0",
+                    "resolved":
+                        "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+                    "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "parse-json": "2.2.0",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1",
+                        "strip-bom": "2.0.0"
+                    }
+                },
+                "parse-json": {
+                    "version": "2.2.0",
+                    "resolved":
+                        "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                    "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+                    "dev": true,
+                    "requires": {
+                        "error-ex": "1.3.1"
+                    }
+                },
+                "path-exists": {
+                    "version": "2.1.0",
+                    "resolved":
+                        "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+                    "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+                    "dev": true,
+                    "requires": {
+                        "pinkie-promise": "2.0.1"
+                    }
+                },
+                "path-type": {
+                    "version": "1.1.0",
+                    "resolved":
+                        "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+                    "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1"
+                    }
+                },
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved":
+                        "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                    "dev": true
+                },
+                "read-pkg": {
+                    "version": "1.1.0",
+                    "resolved":
+                        "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+                    "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+                    "dev": true,
+                    "requires": {
+                        "load-json-file": "1.1.0",
+                        "normalize-package-data": "2.4.0",
+                        "path-type": "1.1.0"
+                    }
+                },
+                "read-pkg-up": {
+                    "version": "1.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+                    "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "1.1.2",
+                        "read-pkg": "1.1.0"
+                    }
+                },
+                "strip-bom": {
+                    "version": "2.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                    "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+                    "dev": true,
+                    "requires": {
+                        "is-utf8": "0.2.1"
+                    }
+                }
+            }
+        },
+        "text-encoding": {
+            "version": "0.6.4",
+            "resolved":
+                "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+            "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+            "dev": true
+        },
+        "text-extensions": {
+            "version": "1.7.0",
+            "resolved":
+                "https://registry.npmjs.org/text-extensions/-/text-extensions-1.7.0.tgz",
+            "integrity":
+                "sha512-AKXZeDq230UaSzaO5s3qQUZOaC7iKbzq0jOFL614R7d9R593HLqAOL0cYoqLdkNrjBSOdmoQI06yigq1TSBXAg==",
+            "dev": true
+        },
+        "text-table": {
+            "version": "0.2.0",
+            "resolved":
+                "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+            "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+        },
+        "textextensions": {
+            "version": "2.2.0",
+            "resolved":
+                "https://registry.npmjs.org/textextensions/-/textextensions-2.2.0.tgz",
+            "integrity":
+                "sha512-j5EMxnryTvKxwH2Cq+Pb43tsf6sdEgw6Pdwxk83mPaq0ToeFJt6WE4J3s5BqY7vmjlLgkgXvhtXUxo80FyBhCA=="
+        },
+        "throat": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
+            "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
+            "dev": true
+        },
+        "through": {
+            "version": "2.3.8",
+            "resolved":
+                "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+        },
+        "through2": {
+            "version": "2.0.3",
+            "resolved":
+                "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+            "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+            "requires": {
+                "readable-stream": "2.3.6",
+                "xtend": "4.0.1"
+            }
+        },
+        "timed-out": {
+            "version": "4.0.1",
+            "resolved":
+                "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+            "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+        },
+        "tmp": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+            "integrity":
+                "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+            "requires": {
+                "os-tmpdir": "1.0.2"
+            }
+        },
+        "tmpl": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+            "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+            "dev": true
+        },
+        "to-fast-properties": {
+            "version": "1.0.3",
+            "resolved":
+                "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+            "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+            "dev": true
+        },
+        "to-object-path": {
+            "version": "0.3.0",
+            "resolved":
+                "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+            "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+            "requires": {
+                "kind-of": "3.2.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved":
+                        "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
+        "to-regex": {
+            "version": "3.0.2",
+            "resolved":
+                "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+            "integrity":
+                "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+            "requires": {
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "regex-not": "1.0.2",
+                "safe-regex": "1.1.0"
+            }
+        },
+        "to-regex-range": {
+            "version": "2.1.1",
+            "resolved":
+                "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+            "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+            "requires": {
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1"
+            }
+        },
+        "tough-cookie": {
+            "version": "2.3.4",
+            "resolved":
+                "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+            "integrity":
+                "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+            "dev": true,
+            "requires": {
+                "punycode": "1.4.1"
+            }
+        },
+        "tr46": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+            "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+            "dev": true,
+            "requires": {
+                "punycode": "2.1.0"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "2.1.0",
+                    "resolved":
+                        "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+                    "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
+                    "dev": true
+                }
+            }
+        },
+        "traverse": {
+            "version": "0.6.6",
+            "resolved":
+                "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+            "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
+            "dev": true
+        },
+        "trim-newlines": {
+            "version": "2.0.0",
+            "resolved":
+                "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+            "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+            "dev": true
+        },
+        "trim-off-newlines": {
+            "version": "1.0.1",
+            "resolved":
+                "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
+            "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
+            "dev": true
+        },
+        "trim-right": {
+            "version": "1.0.1",
+            "resolved":
+                "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+            "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+            "dev": true
+        },
+        "tunnel-agent": {
+            "version": "0.6.0",
+            "resolved":
+                "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "5.1.2"
+            }
+        },
+        "tweetnacl": {
+            "version": "0.14.5",
+            "resolved":
+                "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+            "dev": true,
+            "optional": true
+        },
+        "type-check": {
+            "version": "0.3.2",
+            "resolved":
+                "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+            "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+            "dev": true,
+            "requires": {
+                "prelude-ls": "1.1.2"
+            }
+        },
+        "type-detect": {
+            "version": "4.0.8",
+            "resolved":
+                "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+            "integrity":
+                "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+            "dev": true
+        },
+        "typedarray": {
+            "version": "0.0.6",
+            "resolved":
+                "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+            "dev": true
+        },
+        "uglify-js": {
+            "version": "2.8.29",
+            "resolved":
+                "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+            "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "source-map": "0.5.7",
+                "uglify-to-browserify": "1.0.2",
+                "yargs": "3.10.0"
+            },
+            "dependencies": {
+                "yargs": {
+                    "version": "3.10.0",
+                    "resolved":
+                        "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                    "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "camelcase": "1.2.1",
+                        "cliui": "2.1.0",
+                        "decamelize": "1.2.0",
+                        "window-size": "0.1.0"
+                    }
+                }
+            }
+        },
+        "uglify-to-browserify": {
+            "version": "1.0.2",
+            "resolved":
+                "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+            "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+            "dev": true,
+            "optional": true
+        },
+        "union-value": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+            "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+            "requires": {
+                "arr-union": "3.1.0",
+                "get-value": "2.0.6",
+                "is-extendable": "0.1.1",
+                "set-value": "0.4.3"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "requires": {
+                        "is-extendable": "0.1.1"
+                    }
+                },
+                "set-value": {
+                    "version": "0.4.3",
+                    "resolved":
+                        "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+                    "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+                    "requires": {
+                        "extend-shallow": "2.0.1",
+                        "is-extendable": "0.1.1",
+                        "is-plain-object": "2.0.4",
+                        "to-object-path": "0.3.0"
+                    }
+                }
+            }
+        },
+        "universalify": {
+            "version": "0.1.1",
+            "resolved":
+                "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
+            "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
+            "dev": true
+        },
+        "unset-value": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+            "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+            "requires": {
+                "has-value": "0.3.1",
+                "isobject": "3.0.1"
+            },
+            "dependencies": {
+                "has-value": {
+                    "version": "0.3.1",
+                    "resolved":
+                        "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+                    "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+                    "requires": {
+                        "get-value": "2.0.6",
+                        "has-values": "0.1.4",
+                        "isobject": "2.1.0"
+                    },
+                    "dependencies": {
+                        "isobject": {
+                            "version": "2.1.0",
+                            "resolved":
+                                "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                            "requires": {
+                                "isarray": "1.0.0"
+                            }
+                        }
+                    }
+                },
+                "has-values": {
+                    "version": "0.1.4",
+                    "resolved":
+                        "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+                    "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+                }
+            }
+        },
+        "untildify": {
+            "version": "3.0.2",
+            "resolved":
+                "https://registry.npmjs.org/untildify/-/untildify-3.0.2.tgz",
+            "integrity": "sha1-fx8wIFWz/qDz6B3HjrNnZstl4/E="
+        },
+        "urix": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+            "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+        },
+        "url-join": {
+            "version": "4.0.0",
+            "resolved":
+                "https://registry.npmjs.org/url-join/-/url-join-4.0.0.tgz",
+            "integrity": "sha1-TTNA6AfTdzvamZH4MFrNzCpmXSo=",
+            "dev": true
+        },
+        "url-parse-lax": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+            "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+            "requires": {
+                "prepend-http": "1.0.4"
+            }
+        },
+        "url-template": {
+            "version": "2.0.8",
+            "resolved":
+                "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+            "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE=",
+            "dev": true
+        },
+        "url-to-options": {
+            "version": "1.0.1",
+            "resolved":
+                "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
+            "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
+        },
+        "use": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
+            "integrity":
+                "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
+            "requires": {
+                "kind-of": "6.0.2"
+            }
+        },
+        "util-deprecate": {
+            "version": "1.0.2",
+            "resolved":
+                "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+        },
+        "util.promisify": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+            "integrity":
+                "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+            "dev": true,
+            "requires": {
+                "define-properties": "1.1.2",
+                "object.getownpropertydescriptors": "2.0.3"
+            }
+        },
+        "uuid": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+            "integrity":
+                "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+            "dev": true
+        },
+        "validate-npm-package-license": {
+            "version": "3.0.3",
+            "resolved":
+                "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+            "integrity":
+                "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+            "requires": {
+                "spdx-correct": "3.0.0",
+                "spdx-expression-parse": "3.0.0"
+            }
+        },
+        "verror": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "1.3.0"
+            }
+        },
+        "vinyl": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
+            "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
+            "requires": {
+                "clone": "2.1.1",
+                "clone-buffer": "1.0.0",
+                "clone-stats": "1.0.0",
+                "cloneable-readable": "1.1.2",
+                "remove-trailing-separator": "1.1.0",
+                "replace-ext": "1.0.0"
+            }
+        },
+        "vinyl-file": {
+            "version": "2.0.0",
+            "resolved":
+                "https://registry.npmjs.org/vinyl-file/-/vinyl-file-2.0.0.tgz",
+            "integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
+            "requires": {
+                "graceful-fs": "4.1.11",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1",
+                "strip-bom": "2.0.0",
+                "strip-bom-stream": "2.0.0",
+                "vinyl": "1.2.0"
+            },
+            "dependencies": {
+                "clone": {
+                    "version": "1.0.4",
+                    "resolved":
+                        "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+                    "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+                },
+                "clone-stats": {
+                    "version": "0.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+                    "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
+                },
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved":
+                        "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+                },
+                "replace-ext": {
+                    "version": "0.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+                    "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+                },
+                "strip-bom": {
+                    "version": "2.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                    "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+                    "requires": {
+                        "is-utf8": "0.2.1"
+                    }
+                },
+                "vinyl": {
+                    "version": "1.2.0",
+                    "resolved":
+                        "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+                    "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+                    "requires": {
+                        "clone": "1.0.4",
+                        "clone-stats": "0.0.1",
+                        "replace-ext": "0.0.1"
+                    }
+                }
+            }
+        },
+        "w3c-hr-time": {
+            "version": "1.0.1",
+            "resolved":
+                "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+            "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+            "dev": true,
+            "requires": {
+                "browser-process-hrtime": "0.1.2"
+            }
+        },
+        "walker": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+            "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+            "dev": true,
+            "requires": {
+                "makeerror": "1.0.11"
+            }
+        },
+        "watch": {
+            "version": "0.18.0",
+            "resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
+            "integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
+            "dev": true,
+            "requires": {
+                "exec-sh": "0.2.1",
+                "minimist": "1.2.0"
+            }
+        },
+        "webidl-conversions": {
+            "version": "4.0.2",
+            "resolved":
+                "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+            "integrity":
+                "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+            "dev": true
+        },
+        "whatwg-encoding": {
+            "version": "1.0.3",
+            "resolved":
+                "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
+            "integrity":
+                "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
+            "dev": true,
+            "requires": {
+                "iconv-lite": "0.4.19"
+            },
+            "dependencies": {
+                "iconv-lite": {
+                    "version": "0.4.19",
+                    "resolved":
+                        "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+                    "integrity":
+                        "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+                    "dev": true
+                }
+            }
+        },
+        "whatwg-mimetype": {
+            "version": "2.1.0",
+            "resolved":
+                "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz",
+            "integrity":
+                "sha512-FKxhYLytBQiUKjkYteN71fAUA3g6KpNXoho1isLiLSB3N1G4F35Q5vUxWfKFhBwi5IWF27VE6WxhrnnC+m0Mew==",
+            "dev": true
+        },
+        "whatwg-url": {
+            "version": "6.4.1",
+            "resolved":
+                "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.1.tgz",
+            "integrity":
+                "sha512-FwygsxsXx27x6XXuExA/ox3Ktwcbf+OAvrKmLulotDAiO1Q6ixchPFaHYsis2zZBZSJTR0+dR+JVtf7MlbqZjw==",
+            "dev": true,
+            "requires": {
+                "lodash.sortby": "4.7.0",
+                "tr46": "1.0.1",
+                "webidl-conversions": "4.0.2"
+            }
+        },
+        "which": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+            "integrity":
+                "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+            "requires": {
+                "isexe": "2.0.0"
+            }
+        },
+        "which-module": {
+            "version": "2.0.0",
+            "resolved":
+                "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+            "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+            "dev": true
+        },
+        "window-size": {
+            "version": "0.1.0",
+            "resolved":
+                "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+            "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+            "dev": true,
+            "optional": true
+        },
+        "word-wrap": {
+            "version": "1.2.3",
+            "resolved":
+                "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+            "integrity":
+                "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+            "dev": true
+        },
+        "wordwrap": {
+            "version": "1.0.0",
+            "resolved":
+                "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+            "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+            "dev": true
+        },
+        "wrap-ansi": {
+            "version": "2.1.0",
+            "resolved":
+                "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+            "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+            "requires": {
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved":
+                        "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                    "requires": {
+                        "number-is-nan": "1.0.1"
+                    }
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "resolved":
+                        "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                    "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
+                }
+            }
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+        },
+        "wreck": {
+            "version": "12.5.1",
+            "resolved": "https://registry.npmjs.org/wreck/-/wreck-12.5.1.tgz",
+            "integrity":
+                "sha512-l5DUGrc+yDyIflpty1x9XuMj1ehVjC/dTbF3/BasOO77xk0EdEa4M/DuOY8W88MQDAD0fEDqyjc8bkIMHd2E9A==",
+            "dev": true,
+            "requires": {
+                "boom": "5.2.0",
+                "hoek": "4.2.1"
+            },
+            "dependencies": {
+                "boom": {
+                    "version": "5.2.0",
+                    "resolved":
+                        "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+                    "integrity":
+                        "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+                    "dev": true,
+                    "requires": {
+                        "hoek": "4.2.1"
+                    }
+                }
+            }
+        },
+        "write": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+            "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+            "dev": true,
+            "requires": {
+                "mkdirp": "0.5.1"
+            }
+        },
+        "write-file-atomic": {
+            "version": "2.3.0",
+            "resolved":
+                "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
+            "integrity":
+                "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "4.1.11",
+                "imurmurhash": "0.1.4",
+                "signal-exit": "3.0.2"
+            }
+        },
+        "ws": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
+            "integrity":
+                "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
+            "dev": true,
+            "requires": {
+                "async-limiter": "1.0.0",
+                "safe-buffer": "5.1.2"
+            }
+        },
+        "xml-name-validator": {
+            "version": "3.0.0",
+            "resolved":
+                "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+            "integrity":
+                "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+            "dev": true
+        },
+        "xtend": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+        },
+        "y18n": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+            "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+            "dev": true
+        },
+        "yallist": {
+            "version": "2.1.2",
+            "resolved":
+                "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+            "dev": true
+        },
+        "yargs": {
+            "version": "10.1.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
+            "integrity":
+                "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
+            "dev": true,
+            "requires": {
+                "cliui": "4.1.0",
+                "decamelize": "1.2.0",
+                "find-up": "2.1.0",
+                "get-caller-file": "1.0.2",
+                "os-locale": "2.1.0",
+                "require-directory": "2.1.1",
+                "require-main-filename": "1.0.1",
+                "set-blocking": "2.0.0",
+                "string-width": "2.1.1",
+                "which-module": "2.0.0",
+                "y18n": "3.2.1",
+                "yargs-parser": "8.1.0"
+            },
+            "dependencies": {
+                "cliui": {
+                    "version": "4.1.0",
+                    "resolved":
+                        "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+                    "integrity":
+                        "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "2.1.1",
+                        "strip-ansi": "4.0.0",
+                        "wrap-ansi": "2.1.0"
+                    }
+                }
+            }
+        },
+        "yargs-parser": {
+            "version": "8.1.0",
+            "resolved":
+                "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
+            "integrity":
+                "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+            "dev": true,
+            "requires": {
+                "camelcase": "4.1.0"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "4.1.0",
+                    "resolved":
+                        "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                    "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+                    "dev": true
+                }
+            }
+        },
+        "yeoman-assert": {
+            "version": "3.1.1",
+            "resolved":
+                "https://registry.npmjs.org/yeoman-assert/-/yeoman-assert-3.1.1.tgz",
+            "integrity":
+                "sha512-bCuLb/j/WzpvrJZCTdJJLFzm7KK8IYQJ3+dF9dYtNs2CUYyezFJDuULiZ2neM4eqjf45GN1KH/MzCTT3i90wUQ==",
+            "dev": true
+        },
+        "yeoman-environment": {
+            "version": "2.1.1",
+            "resolved":
+                "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.1.1.tgz",
+            "integrity":
+                "sha512-IBLwCUrJrDxBYuwdYm1wuF3O/CR2LpXR0rFS684QOrU6x69DPPrsdd20dZOFaedZ/M9sON7po73WhO3I1CbgNQ==",
+            "requires": {
+                "chalk": "2.4.1",
+                "cross-spawn": "6.0.5",
+                "debug": "3.1.0",
+                "diff": "3.5.0",
+                "escape-string-regexp": "1.0.5",
+                "globby": "8.0.1",
+                "grouped-queue": "0.3.3",
+                "inquirer": "5.2.0",
+                "is-scoped": "1.0.0",
+                "lodash": "4.17.10",
+                "log-symbols": "2.2.0",
+                "mem-fs": "1.1.3",
+                "strip-ansi": "4.0.0",
+                "text-table": "0.2.0",
+                "untildify": "3.0.2"
+            }
+        },
+        "yeoman-generator": {
+            "version": "2.0.5",
+            "resolved":
+                "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-2.0.5.tgz",
+            "integrity":
+                "sha512-rV6tJ8oYzm4mmdF2T3wjY+Q42jKF2YiiD0VKfJ8/0ZYwmhCKC9Xs2346HVLPj/xE13i68psnFJv7iS6gWRkeAg==",
+            "requires": {
+                "async": "2.6.0",
+                "chalk": "2.4.1",
+                "cli-table": "0.3.1",
+                "cross-spawn": "6.0.5",
+                "dargs": "5.1.0",
+                "dateformat": "3.0.3",
+                "debug": "3.1.0",
+                "detect-conflict": "1.0.1",
+                "error": "7.0.2",
+                "find-up": "2.1.0",
+                "github-username": "4.1.0",
+                "istextorbinary": "2.2.1",
+                "lodash": "4.17.10",
+                "make-dir": "1.3.0",
+                "mem-fs-editor": "4.0.2",
+                "minimist": "1.2.0",
+                "pretty-bytes": "4.0.2",
+                "read-chunk": "2.1.0",
+                "read-pkg-up": "3.0.0",
+                "rimraf": "2.6.2",
+                "run-async": "2.3.0",
+                "shelljs": "0.8.2",
+                "text-table": "0.2.0",
+                "through2": "2.0.3",
+                "yeoman-environment": "2.1.1"
+            }
+        },
+        "yeoman-test": {
+            "version": "1.7.2",
+            "resolved":
+                "https://registry.npmjs.org/yeoman-test/-/yeoman-test-1.7.2.tgz",
+            "integrity":
+                "sha512-4KFaEWcRhLq1QC9EtdU3Miw/QxlEcNcF4VfgQdQsTJOa2nSXL/NVsMTRoMkki7ssYQornCOqGgXJA5/VUICtcw==",
+            "dev": true,
+            "requires": {
+                "inquirer": "5.2.0",
+                "lodash": "4.17.10",
+                "mkdirp": "0.5.1",
+                "pinkie-promise": "2.0.1",
+                "rimraf": "2.6.2",
+                "sinon": "5.0.7",
+                "yeoman-environment": "2.1.1",
+                "yeoman-generator": "2.0.5"
+            }
+        },
+        "yosay": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/yosay/-/yosay-2.0.2.tgz",
+            "integrity":
+                "sha512-avX6nz2esp7IMXGag4gu6OyQBsMh/SEn+ZybGu3yKPlOTE6z9qJrzG/0X5vCq/e0rPFy0CUYCze0G5hL310ibA==",
+            "requires": {
+                "ansi-regex": "2.1.1",
+                "ansi-styles": "3.2.1",
+                "chalk": "1.1.3",
+                "cli-boxes": "1.0.0",
+                "pad-component": "0.0.1",
+                "string-width": "2.1.1",
+                "strip-ansi": "3.0.1",
+                "taketalk": "1.0.0",
+                "wrap-ansi": "2.1.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved":
+                        "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved":
+                        "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "requires": {
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
+                    },
+                    "dependencies": {
+                        "ansi-styles": {
+                            "version": "2.2.1",
+                            "resolved":
+                                "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                            "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+                        }
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved":
+                        "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved":
+                        "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+                }
+            }
         }
-      }
     }
-  }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     },
     "dependencies": {
         "chalk": "^2.1.0",
-        "yeoman-generator": "^2.0.1",
+        "yeoman-generator": "^2.0.5",
         "yosay": "^2.0.1"
     },
     "jest": {


### PR DESCRIPTION
To enable testing across multiple branches with multiple developers, I've added the [AWS Alias Plugin](https://github.com/HyperBrain/serverless-aws-alias) into the default generator. This provides an additional command line argument for deployments that creates new paths on the original API gateway. This can then be used at deploy time to create multiple environments and deployments on the same gateway.

To deploy an alias function with the added scripts, run:

```
yarn run sls-deploy -- --alias=sample
```

Which will create a `/sample/` path on the original gateway URL in place of the stage name configured in serverless.yml.